### PR TITLE
feat: TokenLocalDto 데이터 클래스 생성 및 token data store migration

### DIFF
--- a/data/src/main/java/com/prac/data/repository/TokenRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/TokenRepository.kt
@@ -6,4 +6,16 @@ interface TokenRepository {
     ) : Result<Unit>
 
     suspend fun isLoggedIn() : Boolean
+
+    /**
+     * This methods is intended for internal use by the interceptor and should not be called from the ViewModel.
+     */
+
+    fun getAccessToken() : String
+
+    fun getRefreshToken() : String
+
+    fun getAccessTokenIsExpired() : Boolean
+
+    fun getRefreshTokenIsExpired() : Boolean
 }

--- a/data/src/main/java/com/prac/data/repository/TokenRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/TokenRepository.kt
@@ -11,6 +11,8 @@ interface TokenRepository {
      * This methods is intended for internal use by the interceptor and should not be called from the ViewModel.
      */
 
+    suspend fun refreshToken(refreshToken: String) : Result<Unit>
+
     fun getAccessToken() : String
 
     fun getRefreshToken() : String

--- a/data/src/main/java/com/prac/data/repository/TokenRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/TokenRepository.kt
@@ -7,6 +7,8 @@ interface TokenRepository {
 
     suspend fun isLoggedIn() : Boolean
 
+    suspend fun clearToken()
+
     /**
      * This methods is intended for internal use by the interceptor and should not be called from the ViewModel.
      */

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -32,8 +32,8 @@ internal class TokenRepositoryImpl @Inject constructor(
             TokenLocalDto(
                 token.accessToken,
                 token.refreshToken,
-                token.expiresInMinute,
-                token.refreshTokenExpiresInMinute,
+                token.expiresInSeconds,
+                token.refreshTokenExpiresInSeconds,
                 token.updatedAt
             )
         )

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -27,6 +27,22 @@ internal class TokenRepositoryImpl @Inject constructor(
         return token.accessToken.isNotEmpty()
     }
 
+    override fun getAccessToken(): String {
+        return tokenLocalDataSource.getToken().accessToken
+    }
+
+    override fun getRefreshToken(): String {
+        return tokenLocalDataSource.getToken().refreshToken
+    }
+
+    override fun getAccessTokenIsExpired(): Boolean {
+        return tokenLocalDataSource.getToken().isExpired
+    }
+
+    override fun getRefreshTokenIsExpired(): Boolean {
+        return tokenLocalDataSource.getToken().isRefreshTokenExpired
+    }
+
     private suspend fun setToken(token: TokenModel) {
         tokenLocalDataSource.setToken(
             TokenLocalDto(

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -27,6 +27,17 @@ internal class TokenRepositoryImpl @Inject constructor(
         return token.accessToken.isNotEmpty()
     }
 
+    override suspend fun refreshToken(refreshToken: String): Result<Unit> {
+        return try {
+            val model = tokenApiDataSource.refreshToken(refreshToken)
+            setToken(model)
+
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     override fun getAccessToken(): String {
         return tokenLocalDataSource.getToken().accessToken
     }

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.prac.data.repository.TokenRepository
 import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.network.TokenApiDataSource
 import com.prac.data.source.local.TokenLocalDataSource
+import com.prac.data.source.local.datastore.TokenLocalDto
 import javax.inject.Inject
 
 internal class TokenRepositoryImpl @Inject constructor(
@@ -27,6 +28,14 @@ internal class TokenRepositoryImpl @Inject constructor(
     }
 
     private suspend fun setToken(token: TokenModel) {
-        tokenLocalDataSource.setToken(token)
+        tokenLocalDataSource.setToken(
+            TokenLocalDto(
+                token.accessToken,
+                token.refreshToken,
+                token.expiresInMinute,
+                token.refreshTokenExpiresInMinute,
+                token.updatedAt
+            )
+        )
     }
 }

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -23,8 +23,7 @@ internal class TokenRepositoryImpl @Inject constructor(
     }
 
     override suspend fun isLoggedIn(): Boolean {
-        val token = tokenLocalDataSource.getToken()
-        return token.accessToken.isNotEmpty()
+        return getAccessToken().isNotEmpty()
     }
 
     override suspend fun clearToken() {

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -27,6 +27,10 @@ internal class TokenRepositoryImpl @Inject constructor(
         return token.accessToken.isNotEmpty()
     }
 
+    override suspend fun clearToken() {
+        tokenLocalDataSource.clearToken()
+    }
+
     override suspend fun refreshToken(refreshToken: String): Result<Unit> {
         return try {
             val model = tokenApiDataSource.refreshToken(refreshToken)

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -5,7 +5,7 @@ import java.time.ZonedDateTime
 internal data class TokenModel(
     val accessToken: String,
     val refreshToken: String,
-    val expiresInMinute: Int,
-    val refreshTokenExpiresInMinute: Int,
+    val expiresInSeconds: Int,
+    val refreshTokenExpiresInSeconds: Int,
     val updatedAt: ZonedDateTime
 )

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -8,10 +8,4 @@ internal data class TokenModel(
     val expiresInMinute: Int,
     val refreshTokenExpiresInMinute: Int,
     val updatedAt: ZonedDateTime
-) {
-    val isExpired: Boolean
-        get() = updatedAt.plusMinutes(expiresInMinute.toLong()).isBefore(ZonedDateTime.now())
-
-    val isRefreshTokenExpired: Boolean
-        get() = updatedAt.plusMinutes(refreshTokenExpiresInMinute.toLong()).isBefore(ZonedDateTime.now())
-}
+)

--- a/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
@@ -5,5 +5,5 @@ import com.prac.data.source.local.datastore.TokenLocalDto
 internal interface TokenLocalDataSource {
     suspend fun setToken(token: TokenLocalDto)
 
-    suspend fun getToken(): TokenLocalDto
+    fun getToken(): TokenLocalDto
 }

--- a/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
@@ -1,9 +1,9 @@
 package com.prac.data.source.local
 
-import com.prac.data.repository.model.TokenModel
+import com.prac.data.source.local.datastore.TokenLocalDto
 
 internal interface TokenLocalDataSource {
-    suspend fun setToken(token: TokenModel)
+    suspend fun setToken(token: TokenLocalDto)
 
-    suspend fun getToken(): TokenModel
+    suspend fun getToken(): TokenLocalDto
 }

--- a/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
@@ -6,4 +6,6 @@ internal interface TokenLocalDataSource {
     suspend fun setToken(token: TokenLocalDto)
 
     fun getToken(): TokenLocalDto
+
+    suspend fun clearToken()
 }

--- a/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
@@ -102,8 +102,8 @@ internal class TokenDataStoreManager(
             pref.toBuilder()
                 .setAccessToken(token.accessToken)
                 .setRefreshToken(token.refreshToken)
-                .setAccessTokenExpiresInSeconds(token.expiresInMinute)
-                .setRefreshTokenExpiresInSeconds(token.refreshTokenExpiresInMinute)
+                .setAccessTokenExpiresInSeconds(token.expiresInSeconds)
+                .setRefreshTokenExpiresInSeconds(token.refreshTokenExpiresInSeconds)
                 .setAccessTokenUpdatedAt(token.updatedAt.toInstant().toEpochMilli())
                 .build()
         }
@@ -114,8 +114,8 @@ internal class TokenDataStoreManager(
             TokenLocalDto(
                 accessToken = it.accessToken,
                 refreshToken = it.refreshToken,
-                expiresInMinute = it.accessTokenExpiresInSeconds,
-                refreshTokenExpiresInMinute = it.refreshTokenExpiresInSeconds,
+                expiresInSeconds = it.accessTokenExpiresInSeconds,
+                refreshTokenExpiresInSeconds = it.refreshTokenExpiresInSeconds,
                 updatedAt = Instant.ofEpochMilli(it.accessTokenUpdatedAt).atZone(ZoneId.systemDefault())
             )
         }

--- a/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
@@ -78,6 +78,20 @@ internal class TokenDataStoreManager(
                             .clearIsLoggedIn()
                             .build()
                     }
+                },
+                object : DataMigration<Token> {
+                    override suspend fun cleanUp() {}
+
+                    override suspend fun shouldMigrate(currentData: Token): Boolean {
+                        return (currentData.accessTokenExpiresInMinute > 0) || (currentData.refreshTokenExpiresInMinute > 0)
+                    }
+
+                    override suspend fun migrate(currentData: Token): Token {
+                        return currentData.toBuilder()
+                            .clearAccessTokenExpiresInMinute()
+                            .clearRefreshTokenExpiresInMinute()
+                            .build()
+                    }
                 }
             )
         }
@@ -88,8 +102,8 @@ internal class TokenDataStoreManager(
             pref.toBuilder()
                 .setAccessToken(token.accessToken)
                 .setRefreshToken(token.refreshToken)
-                .setAccessTokenExpiresInMinute(token.expiresInMinute)
-                .setRefreshTokenExpiresInMinute(token.refreshTokenExpiresInMinute)
+                .setAccessTokenExpiresInSeconds(token.expiresInMinute)
+                .setRefreshTokenExpiresInSeconds(token.refreshTokenExpiresInMinute)
                 .setAccessTokenUpdatedAt(token.updatedAt.toInstant().toEpochMilli())
                 .build()
         }
@@ -100,8 +114,8 @@ internal class TokenDataStoreManager(
             TokenLocalDto(
                 accessToken = it.accessToken,
                 refreshToken = it.refreshToken,
-                expiresInMinute = it.accessTokenExpiresInMinute,
-                refreshTokenExpiresInMinute = it.refreshTokenExpiresInMinute,
+                expiresInMinute = it.accessTokenExpiresInSeconds,
+                refreshTokenExpiresInMinute = it.refreshTokenExpiresInSeconds,
                 updatedAt = Instant.ofEpochMilli(it.accessTokenUpdatedAt).atZone(ZoneId.systemDefault())
             )
         }

--- a/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
@@ -10,7 +10,6 @@ import androidx.datastore.migrations.SharedPreferencesMigration
 import androidx.datastore.migrations.SharedPreferencesView
 import com.google.protobuf.InvalidProtocolBufferException
 import com.prac.data.datastore.Token
-import com.prac.data.repository.model.TokenModel
 import kotlinx.coroutines.flow.first
 import java.io.InputStream
 import java.io.OutputStream
@@ -84,7 +83,7 @@ internal class TokenDataStoreManager(
         }
     )
 
-    suspend fun saveTokenData(token: TokenModel) {
+    suspend fun saveTokenData(token: TokenLocalDto) {
         mContext.tokenDataStore.updateData { pref ->
             pref.toBuilder()
                 .setAccessToken(token.accessToken)
@@ -96,9 +95,9 @@ internal class TokenDataStoreManager(
         }
     }
 
-    suspend fun getToken(): TokenModel {
+    suspend fun getToken(): TokenLocalDto {
         return mContext.tokenDataStore.data.first().let {
-            TokenModel(
+            TokenLocalDto(
                 accessToken = it.accessToken,
                 refreshToken = it.refreshToken,
                 expiresInMinute = it.accessTokenExpiresInMinute,

--- a/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
@@ -121,4 +121,12 @@ internal class TokenDataStoreManager(
         }
     }
 
+    suspend fun clearToken() {
+        mContext.tokenDataStore.updateData { pref ->
+            pref.toBuilder()
+                .clear()
+                .build()
+        }
+    }
+
 }

--- a/data/src/main/java/com/prac/data/source/local/datastore/TokenLocalDto.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/TokenLocalDto.kt
@@ -10,8 +10,8 @@ internal data class TokenLocalDto(
     val updatedAt: ZonedDateTime
 ) {
     val isExpired: Boolean
-        get() = updatedAt.plusMinutes(expiresInSeconds.toLong()).isBefore(ZonedDateTime.now())
+        get() = updatedAt.plusSeconds(expiresInSeconds.toLong()).isBefore(ZonedDateTime.now())
 
     val isRefreshTokenExpired: Boolean
-        get() = updatedAt.plusMinutes(refreshTokenExpiresInSeconds.toLong()).isBefore(ZonedDateTime.now())
+        get() = updatedAt.plusSeconds(refreshTokenExpiresInSeconds.toLong()).isBefore(ZonedDateTime.now())
 }

--- a/data/src/main/java/com/prac/data/source/local/datastore/TokenLocalDto.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/TokenLocalDto.kt
@@ -5,13 +5,13 @@ import java.time.ZonedDateTime
 internal data class TokenLocalDto(
     val accessToken: String,
     val refreshToken: String,
-    val expiresInMinute: Int,
-    val refreshTokenExpiresInMinute: Int,
+    val expiresInSeconds: Int,
+    val refreshTokenExpiresInSeconds: Int,
     val updatedAt: ZonedDateTime
 ) {
     val isExpired: Boolean
-        get() = updatedAt.plusMinutes(expiresInMinute.toLong()).isBefore(ZonedDateTime.now())
+        get() = updatedAt.plusMinutes(expiresInSeconds.toLong()).isBefore(ZonedDateTime.now())
 
     val isRefreshTokenExpired: Boolean
-        get() = updatedAt.plusMinutes(refreshTokenExpiresInMinute.toLong()).isBefore(ZonedDateTime.now())
+        get() = updatedAt.plusMinutes(refreshTokenExpiresInSeconds.toLong()).isBefore(ZonedDateTime.now())
 }

--- a/data/src/main/java/com/prac/data/source/local/datastore/TokenLocalDto.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/TokenLocalDto.kt
@@ -1,0 +1,17 @@
+package com.prac.data.source.local.datastore
+
+import java.time.ZonedDateTime
+
+internal data class TokenLocalDto(
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresInMinute: Int,
+    val refreshTokenExpiresInMinute: Int,
+    val updatedAt: ZonedDateTime
+) {
+    val isExpired: Boolean
+        get() = updatedAt.plusMinutes(expiresInMinute.toLong()).isBefore(ZonedDateTime.now())
+
+    val isRefreshTokenExpired: Boolean
+        get() = updatedAt.plusMinutes(refreshTokenExpiresInMinute.toLong()).isBefore(ZonedDateTime.now())
+}

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -1,14 +1,26 @@
 package com.prac.data.source.local.impl
 
 import com.prac.data.source.local.datastore.TokenDataStoreManager
-import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.local.datastore.TokenLocalDto
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 
 internal class TokenLocalDataSourceImpl @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : TokenLocalDataSource {
+
+    private val cachedToken: AtomicReference<TokenLocalDto> = AtomicReference()
+
+    init {
+        runBlocking {
+            val token = tokenDataStoreManager.getToken()
+
+            cachedToken.set(token)
+        }
+    }
+
     override suspend fun setToken(token: TokenLocalDto) {
         tokenDataStoreManager.saveTokenData(token)
     }

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -34,4 +34,11 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
     private fun updateToken(newToken: TokenLocalDto) {
         cachedToken.set(newToken)
     }
+
+    override suspend fun clearToken() {
+        tokenDataStoreManager.clearToken()
+
+        val token = tokenDataStoreManager.getToken()
+        cachedToken.set(token)
+    }
 }

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -25,7 +25,7 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
         tokenDataStoreManager.saveTokenData(token)
     }
 
-    override suspend fun getToken(): TokenLocalDto {
-        return tokenDataStoreManager.getToken()
+    override fun getToken(): TokenLocalDto {
+        return cachedToken.get()
     }
 }

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.prac.data.source.local.impl
 
+import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.local.datastore.TokenDataStoreManager
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.local.datastore.TokenLocalDto
@@ -23,9 +24,14 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
 
     override suspend fun setToken(token: TokenLocalDto) {
         tokenDataStoreManager.saveTokenData(token)
+        updateToken(token)
     }
 
     override fun getToken(): TokenLocalDto {
         return cachedToken.get()
+    }
+
+    private fun updateToken(newToken: TokenLocalDto) {
+        cachedToken.set(newToken)
     }
 }

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -3,16 +3,17 @@ package com.prac.data.source.local.impl
 import com.prac.data.source.local.datastore.TokenDataStoreManager
 import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.local.TokenLocalDataSource
+import com.prac.data.source.local.datastore.TokenLocalDto
 import javax.inject.Inject
 
 internal class TokenLocalDataSourceImpl @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : TokenLocalDataSource {
-    override suspend fun setToken(token: TokenModel) {
+    override suspend fun setToken(token: TokenLocalDto) {
         tokenDataStoreManager.saveTokenData(token)
     }
 
-    override suspend fun getToken(): TokenModel {
+    override suspend fun getToken(): TokenLocalDto {
         return tokenDataStoreManager.getToken()
     }
 }

--- a/data/src/main/java/com/prac/data/source/network/TokenApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/network/TokenApiDataSource.kt
@@ -6,4 +6,6 @@ internal interface TokenApiDataSource {
     suspend fun getToken(
         code: String
     ) : TokenModel
+
+    suspend fun refreshToken(refreshToken: String) : TokenModel
 }

--- a/data/src/main/java/com/prac/data/source/network/di/OkHttpClientModule.kt
+++ b/data/src/main/java/com/prac/data/source/network/di/OkHttpClientModule.kt
@@ -1,6 +1,7 @@
 package com.prac.data.source.network.di
 
 import com.prac.data.BuildConfig
+import com.prac.data.repository.TokenRepository
 import com.prac.data.source.network.di.annotation.AuthOkHttpClient
 import com.prac.data.source.network.di.annotation.BasicOkHttpClient
 import com.prac.data.source.local.datastore.TokenDataStoreManager
@@ -19,8 +20,8 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 internal class OkHttpClientModule {
     @Provides
-    fun provideAuthorizationInterceptor(tokenDataStoreManager: TokenDataStoreManager) : Interceptor =
-        AuthorizationInterceptor(tokenDataStoreManager)
+    fun provideAuthorizationInterceptor(tokenRepository: TokenRepository) : Interceptor =
+        AuthorizationInterceptor(tokenRepository)
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
@@ -24,4 +24,16 @@ internal class TokenApiDataSourceImpl @Inject constructor(
             updatedAt = ZonedDateTime.now()
         )
     }
+
+    override suspend fun refreshToken(refreshToken: String): TokenModel {
+        val response = gitHubAuthService.refreshToken(refreshToken = refreshToken)
+
+        return TokenModel(
+            accessToken = response.accessToken,
+            refreshToken = response.refreshToken,
+            expiresInSeconds = response.expiresIn,
+            refreshTokenExpiresInSeconds = response.refreshTokenExpiresIn,
+            updatedAt = ZonedDateTime.now()
+        )
+    }
 }

--- a/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
@@ -19,8 +19,8 @@ internal class TokenApiDataSourceImpl @Inject constructor(
         return TokenModel(
             accessToken = response.accessToken,
             refreshToken = response.refreshToken,
-            expiresInMinute = response.expiresIn,
-            refreshTokenExpiresInMinute = response.refreshTokenExpiresIn,
+            expiresInSeconds = response.expiresIn,
+            refreshTokenExpiresInSeconds = response.refreshTokenExpiresIn,
             updatedAt = ZonedDateTime.now()
         )
     }

--- a/data/src/main/java/com/prac/data/source/network/service/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/AuthorizationInterceptor.kt
@@ -1,5 +1,6 @@
 package com.prac.data.source.network.service
 
+import com.prac.data.repository.TokenRepository
 import com.prac.data.source.local.datastore.TokenDataStoreManager
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -7,29 +8,15 @@ import okhttp3.Response
 import javax.inject.Inject
 
 internal class AuthorizationInterceptor @Inject constructor(
-    private val tokenDataStoreManager: TokenDataStoreManager
+    private val tokenRepository: TokenRepository
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val accessToken = runBlocking { tokenDataStoreManager.getToken() }
-        if (accessToken.isExpired) {
-            // TODO refresh access token by refresh token
-            // 하지만 refresh 로직은 따로 구현하는 것으로 하고 여기서는 401을 리턴한다.
-            return UNAUTHORIZED
-        }
-        val request = chain.request().newBuilder()
-            .addHeader(AUTHORIZATION, "$AUTHORIZATION_TYPE $accessToken")
-            .build()
-        return chain.proceed(request)
+        return chain.proceed(chain.request())
     }
 
     companion object {
         private const val AUTHORIZATION = "Authorization"
         private const val AUTHORIZATION_TYPE = "Bearer"
-
-        private val UNAUTHORIZED = Response.Builder()
-            .code(401)
-            .message("Unauthorized")
-            .build()
     }
 }

--- a/data/src/main/java/com/prac/data/source/network/service/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/AuthorizationInterceptor.kt
@@ -16,14 +16,15 @@ internal class AuthorizationInterceptor @Inject constructor(
             synchronized(this) {
                 if (tokenRepository.getAccessTokenIsExpired()) {
                     if (tokenRepository.getRefreshTokenIsExpired()) {
-                        // Token 정보 초기화 및 return refreshTokenExpired Request
+                        runBlocking {
+                            tokenRepository.clearToken()
+                        }
                     }
 
                     runBlocking {
                         tokenRepository.refreshToken(tokenRepository.getRefreshToken())
                             .onFailure {
-                                // 잘못된 RefreshToken 또는 인터넷 연결 불안정
-                                // Token 정보 초기화
+                                tokenRepository.clearToken()
                             }
                     }
                 }

--- a/data/src/main/java/com/prac/data/source/network/service/GitHubAuthService.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/GitHubAuthService.kt
@@ -14,4 +14,13 @@ internal interface GitHubAuthService {
         @Query("client_secret") clientSecret: String = BuildConfig.CLIENT_SECRET,
         @Query("code") code: String,
     ): TokenDto
+
+    @POST("login/oauth/access_token")
+    suspend fun refreshToken(
+        @Header("Accept") accept: String = "application/json",
+        @Query("client_id") clientID: String = BuildConfig.CLIENT_ID,
+        @Query("client_secret") clientSecret: String = BuildConfig.CLIENT_SECRET,
+        @Query("grant_type") grantType: String = "refresh_token",
+        @Query("refresh_token") refreshToken: String
+    ): TokenDto
 }

--- a/data/src/main/proto/token.proto
+++ b/data/src/main/proto/token.proto
@@ -7,7 +7,9 @@ message Token {
   string access_token = 1;
   string refresh_token = 2;
   bool is_logged_in = 3 [deprecated = true];
-  int32 access_token_expires_in_minute = 4;
-  int32 refresh_token_expires_in_minute = 5;
-  int64 access_token_updated_at = 6;
+  int32 access_token_expires_in_minute = 4 [deprecated = true];
+  int32 refresh_token_expires_in_minute = 5 [deprecated = true];
+  int32 access_token_expires_in_seconds = 6;
+  int32 refresh_token_expires_in_seconds = 7;
+  int64 access_token_updated_at = 8;
 }


### PR DESCRIPTION
notion - https://www.notion.so/feat-TokenLocalDto-token-data-store-migration-118a26591b618046abc6c050b646827d?pvs=4

# AS-IS

```jsx
suspend fun saveTokenData(token: TokenModel) {
    ....
}

suspend fun getToken(): TokenModel {
    ....
}
```

- 현재 token data store 에서 model data class 인 `TokenModel` 을 참조하고 있다.
- `TokenModel` 의 토큰 만료 시간 변수명을 minutes 으로 하고 있다. 하지만 서버에서 seconds 로 보내주고 있다.

```jsx
message Token {
  ....
  int32 access_token_expires_in_minute = 4;
  int32 refresh_token_expires_in_minute = 5;
  ....
}
```

- 현재 token data store 에서 토큰 만료 시간을 minutes 으로 저장하고 있다. 하지만 서버에서 seconds 로 보내주고 있다.

# TO-BE

```jsx
internal data class TokenLocalDto(
    val accessToken: String,
    val refreshToken: String,
    val expiresInSeconds: Int,
    val refreshTokenExpiresInSeconds: Int,
    val updatedAt: ZonedDateTime
) {
    val isExpired: Boolean
        get() = updatedAt.plusSeconds(expiresInSeconds.toLong()).isBefore(ZonedDateTime.now())

    val isRefreshTokenExpired: Boolean
        get() = updatedAt.plusSeconds(refreshTokenExpiresInSeconds.toLong()).isBefore(ZonedDateTime.now())
}
```

- token data store 에서 사용될 TokenLocalDto 데이터 클래스 생성

```jsx
message Token {
  ....
  int32 access_token_expires_in_minute = 4 [deprecated = true];
  int32 refresh_token_expires_in_minute = 5 [deprecated = true];
  int32 access_token_expires_in_seconds = 6;
  int32 refresh_token_expires_in_seconds = 7;
  ....
}
```

- minutes 에서 seconds 로 migration

- #3 