### PR TITLE
feat: AccessToken 및 RefreshToken 이 만료되었을 때 처리

### DIFF
--- a/data/src/main/java/com/prac/data/repository/TokenRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/TokenRepository.kt
@@ -6,4 +6,16 @@ interface TokenRepository {
     ) : Result<Unit>
 
     suspend fun isLoggedIn() : Boolean
+
+    /**
+     * This methods is intended for internal use by the interceptor and should not be called from the ViewModel.
+     */
+
+    fun getAccessToken() : String
+
+    fun getRefreshToken() : String
+
+    fun getAccessTokenIsExpired() : Boolean
+
+    fun getRefreshTokenIsExpired() : Boolean
 }

--- a/data/src/main/java/com/prac/data/repository/TokenRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/TokenRepository.kt
@@ -11,6 +11,8 @@ interface TokenRepository {
      * This methods is intended for internal use by the interceptor and should not be called from the ViewModel.
      */
 
+    suspend fun refreshToken(refreshToken: String) : Result<Unit>
+
     fun getAccessToken() : String
 
     fun getRefreshToken() : String

--- a/data/src/main/java/com/prac/data/repository/TokenRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/TokenRepository.kt
@@ -7,6 +7,8 @@ interface TokenRepository {
 
     suspend fun isLoggedIn() : Boolean
 
+    suspend fun clearToken()
+
     /**
      * This methods is intended for internal use by the interceptor and should not be called from the ViewModel.
      */

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -27,6 +27,22 @@ internal class TokenRepositoryImpl @Inject constructor(
         return token.accessToken.isNotEmpty()
     }
 
+    override fun getAccessToken(): String {
+        return tokenLocalDataSource.getToken().accessToken
+    }
+
+    override fun getRefreshToken(): String {
+        return tokenLocalDataSource.getToken().refreshToken
+    }
+
+    override fun getAccessTokenIsExpired(): Boolean {
+        return tokenLocalDataSource.getToken().isExpired
+    }
+
+    override fun getRefreshTokenIsExpired(): Boolean {
+        return tokenLocalDataSource.getToken().isRefreshTokenExpired
+    }
+
     private suspend fun setToken(token: TokenModel) {
         tokenLocalDataSource.setToken(
             TokenLocalDto(

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -27,6 +27,17 @@ internal class TokenRepositoryImpl @Inject constructor(
         return token.accessToken.isNotEmpty()
     }
 
+    override suspend fun refreshToken(refreshToken: String): Result<Unit> {
+        return try {
+            val model = tokenApiDataSource.refreshToken(refreshToken)
+            setToken(model)
+
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     override fun getAccessToken(): String {
         return tokenLocalDataSource.getToken().accessToken
     }

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -23,8 +23,7 @@ internal class TokenRepositoryImpl @Inject constructor(
     }
 
     override suspend fun isLoggedIn(): Boolean {
-        val token = tokenLocalDataSource.getToken()
-        return token.accessToken.isNotEmpty()
+        return getAccessToken().isNotEmpty()
     }
 
     override suspend fun clearToken() {

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -27,6 +27,10 @@ internal class TokenRepositoryImpl @Inject constructor(
         return token.accessToken.isNotEmpty()
     }
 
+    override suspend fun clearToken() {
+        tokenLocalDataSource.clearToken()
+    }
+
     override suspend fun refreshToken(refreshToken: String): Result<Unit> {
         return try {
             val model = tokenApiDataSource.refreshToken(refreshToken)

--- a/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
@@ -5,5 +5,5 @@ import com.prac.data.source.local.datastore.TokenLocalDto
 internal interface TokenLocalDataSource {
     suspend fun setToken(token: TokenLocalDto)
 
-    suspend fun getToken(): TokenLocalDto
+    fun getToken(): TokenLocalDto
 }

--- a/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
@@ -6,4 +6,6 @@ internal interface TokenLocalDataSource {
     suspend fun setToken(token: TokenLocalDto)
 
     fun getToken(): TokenLocalDto
+
+    suspend fun clearToken()
 }

--- a/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/TokenDataStoreManager.kt
@@ -121,4 +121,12 @@ internal class TokenDataStoreManager(
         }
     }
 
+    suspend fun clearToken() {
+        mContext.tokenDataStore.updateData { pref ->
+            pref.toBuilder()
+                .clear()
+                .build()
+        }
+    }
+
 }

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -1,14 +1,26 @@
 package com.prac.data.source.local.impl
 
 import com.prac.data.source.local.datastore.TokenDataStoreManager
-import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.local.datastore.TokenLocalDto
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 
 internal class TokenLocalDataSourceImpl @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : TokenLocalDataSource {
+
+    private val cachedToken: AtomicReference<TokenLocalDto> = AtomicReference()
+
+    init {
+        runBlocking {
+            val token = tokenDataStoreManager.getToken()
+
+            cachedToken.set(token)
+        }
+    }
+
     override suspend fun setToken(token: TokenLocalDto) {
         tokenDataStoreManager.saveTokenData(token)
     }

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -34,4 +34,11 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
     private fun updateToken(newToken: TokenLocalDto) {
         cachedToken.set(newToken)
     }
+
+    override suspend fun clearToken() {
+        tokenDataStoreManager.clearToken()
+
+        val token = tokenDataStoreManager.getToken()
+        cachedToken.set(token)
+    }
 }

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -25,7 +25,7 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
         tokenDataStoreManager.saveTokenData(token)
     }
 
-    override suspend fun getToken(): TokenLocalDto {
-        return tokenDataStoreManager.getToken()
+    override fun getToken(): TokenLocalDto {
+        return cachedToken.get()
     }
 }

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.prac.data.source.local.impl
 
+import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.local.datastore.TokenDataStoreManager
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.local.datastore.TokenLocalDto
@@ -23,9 +24,14 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
 
     override suspend fun setToken(token: TokenLocalDto) {
         tokenDataStoreManager.saveTokenData(token)
+        updateToken(token)
     }
 
     override fun getToken(): TokenLocalDto {
         return cachedToken.get()
+    }
+
+    private fun updateToken(newToken: TokenLocalDto) {
+        cachedToken.set(newToken)
     }
 }

--- a/data/src/main/java/com/prac/data/source/network/TokenApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/network/TokenApiDataSource.kt
@@ -6,4 +6,6 @@ internal interface TokenApiDataSource {
     suspend fun getToken(
         code: String
     ) : TokenModel
+
+    suspend fun refreshToken(refreshToken: String) : TokenModel
 }

--- a/data/src/main/java/com/prac/data/source/network/di/OkHttpClientModule.kt
+++ b/data/src/main/java/com/prac/data/source/network/di/OkHttpClientModule.kt
@@ -1,6 +1,7 @@
 package com.prac.data.source.network.di
 
 import com.prac.data.BuildConfig
+import com.prac.data.repository.TokenRepository
 import com.prac.data.source.network.di.annotation.AuthOkHttpClient
 import com.prac.data.source.network.di.annotation.BasicOkHttpClient
 import com.prac.data.source.local.datastore.TokenDataStoreManager
@@ -19,8 +20,8 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 internal class OkHttpClientModule {
     @Provides
-    fun provideAuthorizationInterceptor(tokenDataStoreManager: TokenDataStoreManager) : Interceptor =
-        AuthorizationInterceptor(tokenDataStoreManager)
+    fun provideAuthorizationInterceptor(tokenRepository: TokenRepository) : Interceptor =
+        AuthorizationInterceptor(tokenRepository)
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
@@ -24,4 +24,16 @@ internal class TokenApiDataSourceImpl @Inject constructor(
             updatedAt = ZonedDateTime.now()
         )
     }
+
+    override suspend fun refreshToken(refreshToken: String): TokenModel {
+        val response = gitHubAuthService.refreshToken(refreshToken = refreshToken)
+
+        return TokenModel(
+            accessToken = response.accessToken,
+            refreshToken = response.refreshToken,
+            expiresInSeconds = response.expiresIn,
+            refreshTokenExpiresInSeconds = response.refreshTokenExpiresIn,
+            updatedAt = ZonedDateTime.now()
+        )
+    }
 }

--- a/data/src/main/java/com/prac/data/source/network/service/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/AuthorizationInterceptor.kt
@@ -1,5 +1,6 @@
 package com.prac.data.source.network.service
 
+import com.prac.data.repository.TokenRepository
 import com.prac.data.source.local.datastore.TokenDataStoreManager
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -7,29 +8,15 @@ import okhttp3.Response
 import javax.inject.Inject
 
 internal class AuthorizationInterceptor @Inject constructor(
-    private val tokenDataStoreManager: TokenDataStoreManager
+    private val tokenRepository: TokenRepository
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val accessToken = runBlocking { tokenDataStoreManager.getToken() }
-        if (accessToken.isExpired) {
-            // TODO refresh access token by refresh token
-            // 하지만 refresh 로직은 따로 구현하는 것으로 하고 여기서는 401을 리턴한다.
-            return UNAUTHORIZED
-        }
-        val request = chain.request().newBuilder()
-            .addHeader(AUTHORIZATION, "$AUTHORIZATION_TYPE $accessToken")
-            .build()
-        return chain.proceed(request)
+        return chain.proceed(chain.request())
     }
 
     companion object {
         private const val AUTHORIZATION = "Authorization"
         private const val AUTHORIZATION_TYPE = "Bearer"
-
-        private val UNAUTHORIZED = Response.Builder()
-            .code(401)
-            .message("Unauthorized")
-            .build()
     }
 }

--- a/data/src/main/java/com/prac/data/source/network/service/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/AuthorizationInterceptor.kt
@@ -16,14 +16,15 @@ internal class AuthorizationInterceptor @Inject constructor(
             synchronized(this) {
                 if (tokenRepository.getAccessTokenIsExpired()) {
                     if (tokenRepository.getRefreshTokenIsExpired()) {
-                        // Token 정보 초기화 및 return refreshTokenExpired Request
+                        runBlocking {
+                            tokenRepository.clearToken()
+                        }
                     }
 
                     runBlocking {
                         tokenRepository.refreshToken(tokenRepository.getRefreshToken())
                             .onFailure {
-                                // 잘못된 RefreshToken 또는 인터넷 연결 불안정
-                                // Token 정보 초기화
+                                tokenRepository.clearToken()
                             }
                     }
                 }

--- a/data/src/main/java/com/prac/data/source/network/service/GitHubAuthService.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/GitHubAuthService.kt
@@ -14,4 +14,13 @@ internal interface GitHubAuthService {
         @Query("client_secret") clientSecret: String = BuildConfig.CLIENT_SECRET,
         @Query("code") code: String,
     ): TokenDto
+
+    @POST("login/oauth/access_token")
+    suspend fun refreshToken(
+        @Header("Accept") accept: String = "application/json",
+        @Query("client_id") clientID: String = BuildConfig.CLIENT_ID,
+        @Query("client_secret") clientSecret: String = BuildConfig.CLIENT_SECRET,
+        @Query("grant_type") grantType: String = "refresh_token",
+        @Query("refresh_token") refreshToken: String
+    ): TokenDto
 }


### PR DESCRIPTION
notion - https://www.notion.so/feat-AccessToken-RefreshToken-118a26591b61807ba220d8325cc6e37c?pvs=4

# AS-IS

- 현재 AccessToken 을 갱신하는 Service 가 존재하지 않는다.
- 현재 AccessToken 및 RefreshToken 이 만료되었을 때 따로 처리하고 있지 않다. 하지만 만료를 확인하기 위해 매번 디스크에 접근하는 것은 비효율적이기 때문에 Token 정보를 메모리에 저장해서 사용할 예정.

# TO-BE

```jsx
private val cachedToken: AtomicReference<TokenLocalDto> = AtomicReference()
```

- 메모리에 저장해서 사용할 cachedToken 을 DataSource 에 생성

```jsx
override fun intercept(chain: Interceptor.Chain): Response {
    // 메모리에 저장된 Access Token 이 만료되었는지 검증
    if (tokenRepository.getAccessTokenIsExpired()) {
        synchronized(this) {
            // 메모리에 저장된 Access Token 이 만료되었는지 다시 한 번 검증
            if (tokenRepository.getAccessTokenIsExpired()) {
		// Refresh Token 이 만료되었는지 검증 
                if (tokenRepository.getRefreshTokenIsExpired()) {
                    // TODO token data store clear
                }

                // TODO Refresh Token 을 통해서 AccessToken 갱신
            }
        }
    }

    val accessToken = tokenRepository.getAccessToken()

    val request = chain.request().newBuilder()
        .addHeader(AUTHORIZATION, "$AUTHORIZATION_TYPE $accessToken")
        .build()

    return chain.proceed(request)
}
```

- 인터셉터의 intercept 메서드에서 AccessToken 및 RefreshToken 이 만료되었을 때 로직 추가