### PR TITLE
refact: TokenApiDataSource 에서 AuthApiDataSource 으로 이름 변경 및 메서드명 변경

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
@@ -3,7 +3,6 @@ package com.prac.githubrepo.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.prac.data.exception.GitHubApiException
-import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -69,7 +68,7 @@ class LoginViewModel @Inject constructor(
 
             setUiState(UiState.Loading)
 
-            tokenRepository.getTokenApi(code = code)
+            tokenRepository.authorizeOAuth(code = code)
                 .onSuccess {
                     setEvent(Event.Success)
                 }.onFailure { throwable ->

--- a/data/src/main/java/com/prac/data/repository/TokenRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/TokenRepository.kt
@@ -1,7 +1,7 @@
 package com.prac.data.repository
 
 interface TokenRepository {
-    suspend fun getTokenApi(
+    suspend fun authorizeOAuth(
         code: String
     ) : Result<Unit>
 

--- a/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
+++ b/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
@@ -6,7 +6,7 @@ import com.prac.data.repository.impl.RepoRepositoryImpl
 import com.prac.data.repository.impl.TokenRepositoryImpl
 import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
-import com.prac.data.source.network.TokenApiDataSource
+import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.local.room.database.RepositoryDatabase
 import dagger.Module
@@ -22,9 +22,9 @@ internal class RepositoryModule {
     @Singleton
     fun provideTokenRepository(
         tokenLocalDataSource: TokenLocalDataSource,
-        tokenApiDataSource: TokenApiDataSource
+        authApiDataSource: AuthApiDataSource
     ): TokenRepository =
-        TokenRepositoryImpl(tokenLocalDataSource, tokenApiDataSource)
+        TokenRepositoryImpl(tokenLocalDataSource, authApiDataSource)
 
     @Provides
     fun provideRepoRepository(

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -11,7 +11,7 @@ internal class TokenRepositoryImpl @Inject constructor(
     private val tokenLocalDataSource: TokenLocalDataSource,
     private val authApiDataSource: AuthApiDataSource
 ) : TokenRepository {
-    override suspend fun getTokenApi(code: String): Result<Unit> {
+    override suspend fun authorizeOAuth(code: String): Result<Unit> {
         try {
             val model = authApiDataSource.authorizeOAuth(code)
             setToken(model)

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -13,7 +13,7 @@ internal class TokenRepositoryImpl @Inject constructor(
 ) : TokenRepository {
     override suspend fun getTokenApi(code: String): Result<Unit> {
         try {
-            val model = tokenApiDataSource.getToken(code)
+            val model = tokenApiDataSource.authorizeOAuth(code)
             setToken(model)
 
             return Result.success(Unit)

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -2,18 +2,18 @@ package com.prac.data.repository.impl
 
 import com.prac.data.repository.TokenRepository
 import com.prac.data.repository.model.TokenModel
-import com.prac.data.source.network.TokenApiDataSource
+import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.local.datastore.TokenLocalDto
 import javax.inject.Inject
 
 internal class TokenRepositoryImpl @Inject constructor(
     private val tokenLocalDataSource: TokenLocalDataSource,
-    private val tokenApiDataSource: TokenApiDataSource
+    private val authApiDataSource: AuthApiDataSource
 ) : TokenRepository {
     override suspend fun getTokenApi(code: String): Result<Unit> {
         try {
-            val model = tokenApiDataSource.authorizeOAuth(code)
+            val model = authApiDataSource.authorizeOAuth(code)
             setToken(model)
 
             return Result.success(Unit)
@@ -32,7 +32,7 @@ internal class TokenRepositoryImpl @Inject constructor(
 
     override suspend fun refreshToken(refreshToken: String): Result<Unit> {
         return try {
-            val model = tokenApiDataSource.refreshAccessToken(refreshToken)
+            val model = authApiDataSource.refreshAccessToken(refreshToken)
             setToken(model)
 
             Result.success(Unit)

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -32,7 +32,7 @@ internal class TokenRepositoryImpl @Inject constructor(
 
     override suspend fun refreshToken(refreshToken: String): Result<Unit> {
         return try {
-            val model = tokenApiDataSource.refreshToken(refreshToken)
+            val model = tokenApiDataSource.refreshAccessToken(refreshToken)
             setToken(model)
 
             Result.success(Unit)

--- a/data/src/main/java/com/prac/data/source/network/AuthApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/network/AuthApiDataSource.kt
@@ -2,7 +2,7 @@ package com.prac.data.source.network
 
 import com.prac.data.repository.model.TokenModel
 
-internal interface TokenApiDataSource {
+internal interface AuthApiDataSource {
     suspend fun authorizeOAuth(code: String) : TokenModel
 
     suspend fun refreshAccessToken(refreshToken: String) : TokenModel

--- a/data/src/main/java/com/prac/data/source/network/TokenApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/network/TokenApiDataSource.kt
@@ -5,5 +5,5 @@ import com.prac.data.repository.model.TokenModel
 internal interface TokenApiDataSource {
     suspend fun authorizeOAuth(code: String) : TokenModel
 
-    suspend fun refreshToken(refreshToken: String) : TokenModel
+    suspend fun refreshAccessToken(refreshToken: String) : TokenModel
 }

--- a/data/src/main/java/com/prac/data/source/network/TokenApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/network/TokenApiDataSource.kt
@@ -3,9 +3,7 @@ package com.prac.data.source.network
 import com.prac.data.repository.model.TokenModel
 
 internal interface TokenApiDataSource {
-    suspend fun getToken(
-        code: String
-    ) : TokenModel
+    suspend fun authorizeOAuth(code: String) : TokenModel
 
     suspend fun refreshToken(refreshToken: String) : TokenModel
 }

--- a/data/src/main/java/com/prac/data/source/network/di/DataSourceModule.kt
+++ b/data/src/main/java/com/prac/data/source/network/di/DataSourceModule.kt
@@ -3,13 +3,13 @@ package com.prac.data.source.network.di
 import com.prac.data.source.local.datastore.TokenDataStoreManager
 import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
-import com.prac.data.source.network.TokenApiDataSource
+import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.network.service.GitHubService
 import com.prac.data.source.network.service.GitHubAuthService
 import com.prac.data.source.network.impl.RepoApiDataSourceImpl
 import com.prac.data.source.network.impl.RepoStarApiDataSourceImpl
-import com.prac.data.source.network.impl.TokenApiDataSourceImpl
+import com.prac.data.source.network.impl.AuthApiDataSourceImpl
 import com.prac.data.source.local.impl.TokenLocalDataSourceImpl
 import dagger.Module
 import dagger.Provides
@@ -20,10 +20,10 @@ import dagger.hilt.components.SingletonComponent
 @InstallIn(SingletonComponent::class)
 internal class DataSourceModule {
     @Provides
-    fun provideTokenApiDataSource(
+    fun provideAuthApiDataSource(
         gitHubAuthService: GitHubAuthService
-    ): TokenApiDataSource =
-        TokenApiDataSourceImpl(gitHubAuthService)
+    ): AuthApiDataSource =
+        AuthApiDataSourceImpl(gitHubAuthService)
 
     @Provides
     fun provideTokenLocalDataSource(

--- a/data/src/main/java/com/prac/data/source/network/impl/AuthApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/AuthApiDataSourceImpl.kt
@@ -1,14 +1,14 @@
 package com.prac.data.source.network.impl
 
 import com.prac.data.repository.model.TokenModel
-import com.prac.data.source.network.TokenApiDataSource
+import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.network.service.GitHubAuthService
 import java.time.ZonedDateTime
 import javax.inject.Inject
 
-internal class TokenApiDataSourceImpl @Inject constructor(
+internal class AuthApiDataSourceImpl @Inject constructor(
     private val gitHubAuthService: GitHubAuthService
-) : TokenApiDataSource {
+) : AuthApiDataSource {
     override suspend fun authorizeOAuth(code: String): TokenModel {
         val response = gitHubAuthService.authorizeOAuth(code = code)
 

--- a/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
@@ -24,7 +24,7 @@ internal class TokenApiDataSourceImpl @Inject constructor(
     }
 
     override suspend fun refreshToken(refreshToken: String): TokenModel {
-        val response = gitHubAuthService.refreshToken(refreshToken = refreshToken)
+        val response = gitHubAuthService.refreshAccessToken(refreshToken = refreshToken)
 
         return TokenModel(
             accessToken = response.accessToken,

--- a/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
@@ -9,9 +9,7 @@ import javax.inject.Inject
 internal class TokenApiDataSourceImpl @Inject constructor(
     private val gitHubAuthService: GitHubAuthService
 ) : TokenApiDataSource {
-    override suspend fun getToken(
-        code: String
-    ): TokenModel {
+    override suspend fun authorizeOAuth(code: String): TokenModel {
         val response = gitHubAuthService.authorizeOAuth(code = code)
 
         return TokenModel(

--- a/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
@@ -21,7 +21,7 @@ internal class TokenApiDataSourceImpl @Inject constructor(
         )
     }
 
-    override suspend fun refreshToken(refreshToken: String): TokenModel {
+    override suspend fun refreshAccessToken(refreshToken: String): TokenModel {
         val response = gitHubAuthService.refreshAccessToken(refreshToken = refreshToken)
 
         return TokenModel(

--- a/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/TokenApiDataSourceImpl.kt
@@ -12,9 +12,7 @@ internal class TokenApiDataSourceImpl @Inject constructor(
     override suspend fun getToken(
         code: String
     ): TokenModel {
-        val response = gitHubAuthService.getAccessTokenApi(
-            code = code
-        )
+        val response = gitHubAuthService.authorizeOAuth(code = code)
 
         return TokenModel(
             accessToken = response.accessToken,

--- a/data/src/main/java/com/prac/data/source/network/service/GitHubAuthService.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/GitHubAuthService.kt
@@ -16,7 +16,7 @@ internal interface GitHubAuthService {
     ): TokenDto
 
     @POST("login/oauth/access_token")
-    suspend fun refreshToken(
+    suspend fun refreshAccessToken(
         @Header("Accept") accept: String = "application/json",
         @Query("client_id") clientID: String = BuildConfig.CLIENT_ID,
         @Query("client_secret") clientSecret: String = BuildConfig.CLIENT_SECRET,

--- a/data/src/main/java/com/prac/data/source/network/service/GitHubAuthService.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/GitHubAuthService.kt
@@ -8,7 +8,7 @@ import retrofit2.http.Query
 
 internal interface GitHubAuthService {
     @POST("login/oauth/access_token")
-    suspend fun getAccessTokenApi(
+    suspend fun authorizeOAuth(
         @Header("Accept") accept: String = "application/json",
         @Query("client_id") clientID: String = BuildConfig.CLIENT_ID,
         @Query("client_secret") clientSecret: String = BuildConfig.CLIENT_SECRET,


### PR DESCRIPTION
notion - https://www.notion.so/refact-TokenApiDataSource-AuthApiDataSource-118a26591b6180f891bdc3c640fe0c7b?pvs=4

# TO-BE

- 클래스 이름 변경이 Auth 기능을 반영하기 위한 것임을 명시적으로 나타냅니다.