### PR TITLE
refact: repositories 관련 에러 처리

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/constants/ErrorMessage.kt
+++ b/app/src/main/java/com/prac/githubrepo/constants/ErrorMessage.kt
@@ -2,3 +2,4 @@ package com.prac.githubrepo.constants
 
 const val LOGIN_FAIL = "로그인을 실패했습니다."
 const val CONNECTION_FAIL = "연결에 실패했습니다."
+const val INVALID_TOKEN = "토큰이 만료되었습니다. 다시 로그인해주세요."

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.prac.githubrepo.main
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -17,8 +16,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import com.prac.githubrepo.main.MainViewModel.UiState
 import com.prac.githubrepo.main.detail.DetailActivity
-import com.prac.githubrepo.main.detail.DetailActivity.Companion.REPO_NAME
-import com.prac.githubrepo.main.detail.DetailActivity.Companion.USER_NAME
 import com.prac.githubrepo.main.request.StarStateRequestBuilder
 import kotlinx.coroutines.flow.collectLatest
 import java.io.IOException
@@ -109,7 +106,7 @@ class MainActivity : AppCompatActivity() {
     private suspend fun UiState.handleUiState() {
         when (this) {
             is UiState.Idle -> { }
-            is UiState.ShowPagingData -> {
+            is UiState.Content -> {
                 this.loadState?.let { retryFooterAdapter.loadState = it }
 
                 mainAdapter.submitData(this.repositories)

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -21,6 +21,7 @@ import com.prac.githubrepo.main.detail.DetailActivity.Companion.REPO_NAME
 import com.prac.githubrepo.main.detail.DetailActivity.Companion.USER_NAME
 import com.prac.githubrepo.main.request.StarStateRequestBuilder
 import kotlinx.coroutines.flow.collectLatest
+import java.io.IOException
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -81,12 +82,28 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun CombinedLoadStates.handleLoadStates() {
-        if (source.refresh is LoadState.Error || source.refresh is LoadState.Loading) {
-            viewModel.updateLoadState(source.refresh)
+        if (refresh is LoadState.Error) {
+            if ((refresh as LoadState.Error).error !is IOException) {
+                // TODO 로그아웃 예정
+                return
+            }
+            viewModel.updateLoadState(refresh)
+        }
+
+        if (refresh is LoadState.Loading) {
+            viewModel.updateLoadState(refresh)
             return
         }
 
-        viewModel.updateLoadState(source.append)
+        if (append is LoadState.Error) {
+             if ((append as LoadState.Error).error !is IOException) {
+                // TODO 로그아웃 예정
+                return
+            }
+            viewModel.updateLoadState(append)
+        }
+
+        viewModel.updateLoadState(append)
     }
 
     private suspend fun UiState.handleUiState() {

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.prac.githubrepo.main
 
+import android.app.AlertDialog
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -11,6 +12,7 @@ import androidx.paging.LoadState
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.prac.data.entity.RepoEntity
+import com.prac.githubrepo.R
 import com.prac.githubrepo.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -107,6 +109,18 @@ class MainActivity : AppCompatActivity() {
         when (this) {
             is UiState.Idle -> { }
             is UiState.Content -> {
+                if (dialogMessage.isNotEmpty()) {
+                    AlertDialog.Builder(this@MainActivity)
+                        .setMessage(dialogMessage)
+                        .setPositiveButton(R.string.check) { dialog, _ ->
+                            dialog.dismiss()
+                        }
+                        .setOnDismissListener {
+
+                        }
+                        .show()
+                }
+
                 this.loadState?.let { retryFooterAdapter.loadState = it }
 
                 mainAdapter.submitData(this.repositories)

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -83,7 +83,7 @@ class MainActivity : AppCompatActivity() {
     private fun CombinedLoadStates.handleLoadStates() {
         if (refresh is LoadState.Error) {
             if ((refresh as LoadState.Error).error !is IOException) {
-                // TODO 로그아웃 예정
+                viewModel.logout()
                 return
             }
             viewModel.updateLoadState(refresh)
@@ -96,7 +96,7 @@ class MainActivity : AppCompatActivity() {
 
         if (append is LoadState.Error) {
              if ((append as LoadState.Error).error !is IOException) {
-                // TODO 로그아웃 예정
+                viewModel.logout()
                 return
             }
             viewModel.updateLoadState(append)

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -25,7 +25,7 @@ class MainViewModel @Inject constructor(
     sealed class UiState {
         data object Idle : UiState()
 
-        data class ShowPagingData(
+        data class Content(
             val repositories : PagingData<RepoEntity>,
             val loadState: LoadState? = null
         ) : UiState()
@@ -39,16 +39,16 @@ class MainViewModel @Inject constructor(
             if (_uiState.value != UiState.Idle) return@launch
 
             repoRepository.getRepositories().cachedIn(viewModelScope).collect { pagingData ->
-                _uiState.update { UiState.ShowPagingData(pagingData) }
+                _uiState.update { UiState.Content(pagingData) }
             }
         }
     }
 
     fun updateLoadState(loadState: LoadState) {
-        if (_uiState.value !is UiState.ShowPagingData) return
+        if (_uiState.value !is UiState.Content) return
 
         _uiState.update {
-            (it as UiState.ShowPagingData).copy(loadState = loadState)
+            (it as UiState.Content).copy(loadState = loadState)
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -27,7 +27,8 @@ class MainViewModel @Inject constructor(
 
         data class Content(
             val repositories : PagingData<RepoEntity>,
-            val loadState: LoadState? = null
+            val loadState: LoadState? = null,
+            val dialogMessage: String = ""
         ) : UiState()
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -7,6 +7,8 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
+import com.prac.data.repository.TokenRepository
+import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -20,6 +22,7 @@ import javax.inject.Inject
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val repoRepository: RepoRepository,
+    private val tokenRepository: TokenRepository,
     private val backOffWorkManager: BackOffWorkManager
 ): ViewModel() {
     sealed class UiState {
@@ -94,6 +97,18 @@ class MainViewModel @Inject constructor(
                 }
         }
     }
+
+    fun logout() {
+        viewModelScope.launch {
+            tokenRepository.clearToken()
+            backOffWorkManager.clearWork()
+
+            _uiState.update {
+                (it as UiState.Content).copy(dialogMessage = INVALID_TOKEN)
+            }
+        }
+    }
+
 
     init {
         getRepositories()

--- a/app/src/main/java/com/prac/githubrepo/main/RetryFooterAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RetryFooterAdapter.kt
@@ -6,6 +6,7 @@ import androidx.core.view.isVisible
 import androidx.paging.LoadState
 import androidx.paging.LoadStateAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.databinding.ItemRetryFooterBinding
 
 class RetryFooterAdapter(
@@ -22,7 +23,7 @@ class RetryFooterAdapter(
 
         private fun LoadState.setErrorMessage() {
             if (this is LoadState.Error) {
-                binding.tvErrorMessage.text = this.error.localizedMessage
+                binding.tvErrorMessage.text = CONNECTION_FAIL
             }
 
             binding.tvErrorMessage.isVisible = this is LoadState.Error


### PR DESCRIPTION
notion - https://www.notion.so/refact-repositories-118a26591b61802b8499ede59b69a8d9?pvs=4

# AS-IS

- 현재 `CombinedLoadStates` 의 source 를 통해서만 에러를 처리하고 있다.
- 현재 토큰이 만료되었을 때 로그아웃 처리를 하고 있지 않다.
- 현재 UiState 에서 alert dialog 를 띄워주기 위한 변수가 존재하지 않는다.

# TO-BE

```jsx
if (refresh is LoadState.Error) {
    if ((refresh as LoadState.Error).error !is IOException) {
        // 토큰이 만료된 경우
        // 로그아웃
        return
    }
    // update loadstate
}

if (refresh is LoadState.Loading) {
    // update loadstate
    return
}

if (append is LoadState.Error) {
     if ((append as LoadState.Error).error !is IOException) {
        // 토큰이 만료된 경우
        // 로그아웃
        return
    }
    // update loadstate
}

// update loadstate
```

- 기존에는 source 를 통해서만 에러 및 로딩을 처리하고 있었지만 mediator 와 source 모두를 사용해서 에러 및 로딩을 처리하도록 수정
- 로그아웃 처리

```jsx
  data class Content(
      val repositories : PagingData<RepoEntity>,
      val loadState: LoadState? = null,
      val dialogMessage: String = ""
  ) : UiState()
```

- 기존의 ShowPagingData 를 Content 로 변경하고 dialogMessage 변수 추가