### PR TITLE
feat: MainViewModel SideEffect sealed class 생성

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -48,7 +48,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 override fun unStar(repoEntity: RepoEntity) {
-                    viewModel.unStarRepository(repoEntity)
+                    viewModel.setSideEffect(SideEffect.UnStarClick(repoEntity))
                 }
             }
         )
@@ -153,7 +153,9 @@ class MainActivity : AppCompatActivity() {
                 viewModel.starRepository(repoEntity)
             }
 
-            is SideEffect.UnStarClick -> { }
+            is SideEffect.UnStarClick -> {
+                viewModel.unStarRepository(repoEntity)
+            }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -156,6 +156,8 @@ class MainActivity : AppCompatActivity() {
             is SideEffect.UnStarClick -> {
                 viewModel.unStarRepository(repoEntity)
             }
+
+            is SideEffect.RepositoryClick -> { }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -152,6 +152,8 @@ class MainActivity : AppCompatActivity() {
             is SideEffect.StarClick -> {
                 viewModel.starRepository(repoEntity)
             }
+
+            is SideEffect.UnStarClick -> { }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -149,6 +149,7 @@ class MainActivity : AppCompatActivity() {
                 finish()
             }
             is SideEffect.StarDialogDismiss -> { }
+            is SideEffect.StarClick -> { }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -44,7 +44,7 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 override fun star(repoEntity: RepoEntity) {
-                    viewModel.starRepository(repoEntity)
+                    viewModel.setSideEffect(SideEffect.StarClick(repoEntity))
                 }
 
                 override fun unStar(repoEntity: RepoEntity) {
@@ -149,7 +149,9 @@ class MainActivity : AppCompatActivity() {
                 finish()
             }
             is SideEffect.StarDialogDismiss -> { }
-            is SideEffect.StarClick -> { }
+            is SideEffect.StarClick -> {
+                viewModel.starRepository(repoEntity)
+            }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.prac.data.entity.RepoEntity
 import com.prac.githubrepo.R
+import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.databinding.ActivityMainBinding
 import com.prac.githubrepo.login.LoginActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -127,7 +128,7 @@ class MainActivity : AppCompatActivity() {
                             dialog.dismiss()
                         }
                         .setOnDismissListener {
-
+                            handleDialogMessage(dialogMessage)
                         }
                         .show()
                 }
@@ -149,5 +150,14 @@ class MainActivity : AppCompatActivity() {
             }
             is SideEffect.StarDialogDismiss -> { }
         }
+    }
+
+    private fun handleDialogMessage(dialogMessage: String) {
+        if (dialogMessage == INVALID_TOKEN) {
+            viewModel.setSideEffect(SideEffect.LogoutDialogDismiss)
+            return
+        }
+
+        viewModel.setSideEffect(SideEffect.StarDialogDismiss)
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -38,9 +38,7 @@ class MainActivity : AppCompatActivity() {
             starStateRequestBuilderFactory.create(this.lifecycleScope),
             object : MainAdapter.OnRepositoryClickListener {
                 override fun clickRepository(repoEntity: RepoEntity) {
-                    val intent = DetailActivity.createIntent(this@MainActivity, repoEntity.owner.login, repoEntity.name)
-
-                    startActivity(intent)
+                    viewModel.setSideEffect(SideEffect.RepositoryClick(repoEntity))
                 }
 
                 override fun star(repoEntity: RepoEntity) {
@@ -157,7 +155,11 @@ class MainActivity : AppCompatActivity() {
                 viewModel.unStarRepository(repoEntity)
             }
 
-            is SideEffect.RepositoryClick -> { }
+            is SideEffect.RepositoryClick -> {
+                val intent = DetailActivity.createIntent(this@MainActivity, repoEntity.owner.login, repoEntity.name)
+
+                startActivity(intent)
+            }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -147,6 +147,7 @@ class MainActivity : AppCompatActivity() {
 
                 finish()
             }
+            is SideEffect.StarDialogDismiss -> { }
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.prac.githubrepo.main
 
 import android.app.AlertDialog
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -14,9 +15,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.prac.data.entity.RepoEntity
 import com.prac.githubrepo.R
 import com.prac.githubrepo.databinding.ActivityMainBinding
+import com.prac.githubrepo.login.LoginActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import com.prac.githubrepo.main.MainViewModel.UiState
+import com.prac.githubrepo.main.MainViewModel.SideEffect
 import com.prac.githubrepo.main.detail.DetailActivity
 import com.prac.githubrepo.main.request.StarStateRequestBuilder
 import kotlinx.coroutines.flow.collectLatest
@@ -78,6 +81,14 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.sideEffect.collect {
+                    it.handleSideEffect()
+                }
+            }
+        }
     }
 
     private fun CombinedLoadStates.handleLoadStates() {
@@ -124,6 +135,17 @@ class MainActivity : AppCompatActivity() {
                 this.loadState?.let { retryFooterAdapter.loadState = it }
 
                 mainAdapter.submitData(this.repositories)
+            }
+        }
+    }
+
+    private fun SideEffect.handleSideEffect() {
+        when (this) {
+            is SideEffect.LogoutDialogDismiss -> {
+                val intent = Intent(this@MainActivity, LoginActivity::class.java)
+                startActivity(intent)
+
+                finish()
             }
         }
     }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -40,8 +40,8 @@ class MainViewModel @Inject constructor(
 
     sealed class SideEffect {
         data object LogoutDialogDismiss : SideEffect()
-
         data object StarDialogDismiss : SideEffect()
+        data class StarClick(val repoEntity: RepoEntity) : SideEffect()
     }
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -13,7 +13,9 @@ import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -36,8 +38,21 @@ class MainViewModel @Inject constructor(
         ) : UiState()
     }
 
+    sealed class SideEffect {
+        data object LogoutDialogDismiss : SideEffect()
+    }
+
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<SideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
+
+    fun setSideEffect(sideEffect: SideEffect) {
+        viewModelScope.launch {
+            _sideEffect.emit(sideEffect)
+        }
+    }
 
     private fun getRepositories() {
         viewModelScope.launch {

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -43,6 +43,7 @@ class MainViewModel @Inject constructor(
         data object StarDialogDismiss : SideEffect()
         data class StarClick(val repoEntity: RepoEntity) : SideEffect()
         data class UnStarClick(val repoEntity: RepoEntity) : SideEffect()
+        data class RepositoryClick(val repoEntity: RepoEntity) : SideEffect()
     }
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -42,6 +42,7 @@ class MainViewModel @Inject constructor(
         data object LogoutDialogDismiss : SideEffect()
         data object StarDialogDismiss : SideEffect()
         data class StarClick(val repoEntity: RepoEntity) : SideEffect()
+        data class UnStarClick(val repoEntity: RepoEntity) : SideEffect()
     }
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -40,6 +40,8 @@ class MainViewModel @Inject constructor(
 
     sealed class SideEffect {
         data object LogoutDialogDismiss : SideEffect()
+
+        data object StarDialogDismiss : SideEffect()
     }
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)


### PR DESCRIPTION
notion - https://www.notion.so/feat-MainViewModel-SideEffect-sealed-class-118a26591b6180568652e7d777a4beb0?pvs=4

# AS-IS

- 현재 dialog dismiss, star, unstar 및 repository 를 클릭했을 때 SideEffect 를 발행하기 위한 sealed class 및 변수가 존재하지 않는다.

# TO-BE

```jsx
sealed class SideEffect {
    data object LogoutDialogDismiss : SideEffect()
    data object StarDialogDismiss : SideEffect()
    data class StarClick(val repoEntity: RepoEntity) : SideEffect()
    data class UnStarClick(val repoEntity: RepoEntity) : SideEffect()
    data class RepositoryClick(val repoEntity: RepoEntity) : SideEffect()
}

```

- 현재 dialo dismiss, star, unstar 및 repository 를 클릭했을 때 SideEffect 를 발행하기 위한 sealed class 생성