### PR TITLE
refact: repository 관련 에러 처리

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
@@ -61,7 +61,7 @@ class DetailActivity : AppCompatActivity() {
             is UiState.Loading -> {
                 binding.includeProgressBar.root.isVisible = true
             }
-            is UiState.ShowRepository -> {
+            is UiState.Content -> {
                 binding.includeProgressBar.root.isVisible = false
 
                 bindRepositoryDetail(this.repository)

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.constants.CONNECTION_FAIL
+import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -72,8 +74,23 @@ class DetailViewModel @Inject constructor(
                     }
                 }
                 .onFailure { throwable ->
-                    _uiState.update {
-                        UiState.Error(throwable.message.toString())
+                    when (throwable) {
+                        is IOException -> {
+                            _uiState.update {
+                                UiState.Error(errorMessage = CONNECTION_FAIL)
+                            }
+                        }
+                        else -> {
+                            if (throwable.message?.contains("404") == true) {
+                                _uiState.update {
+                                    UiState.Error(errorMessage = INVALID_REPOSITORY)
+                                }
+
+                                return@onFailure
+                            }
+
+                            // TODO 로그아웃
+                        }
                     }
                 }
         }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -92,7 +92,7 @@ class DetailViewModel @Inject constructor(
                                 return@onFailure
                             }
 
-                            // TODO 로그아웃
+                            logout()
                         }
                     }
                 }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -27,7 +27,7 @@ class DetailViewModel @Inject constructor(
 
         data object Loading : UiState()
 
-        data class ShowRepository(
+        data class Content(
             val repository : RepoDetailEntity
         ) : UiState()
 
@@ -69,7 +69,7 @@ class DetailViewModel @Inject constructor(
                         }
 
                         _uiState.update {
-                            UiState.ShowRepository(repoDetailEntity.copy(isStarred = isStarred, stargazersCount = stargazersCount))
+                            UiState.Content(repoDetailEntity.copy(isStarred = isStarred, stargazersCount = stargazersCount))
                         }
                     }
                 }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -58,7 +58,7 @@ class DetailViewModel @Inject constructor(
 
                         // Room 에서 repoDetailEntity.id 값이 없을 경우에 null 을 반환한다.
                         if (stargazersCount == null) {
-                            _uiState.update { UiState.Error("존재하지 않는 레파지토리입니다.") }
+                            _uiState.update { UiState.Error(errorMessage = INVALID_REPOSITORY) }
                             return@collect
                         }
 

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.repository.RepoRepository
+import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
+import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -20,6 +22,7 @@ import javax.inject.Inject
 @HiltViewModel
 class DetailViewModel @Inject constructor(
     private val repoRepository: RepoRepository,
+    private val tokenRepository: TokenRepository,
     private val backOffWorkManager: BackOffWorkManager
 ) : ViewModel() {
     sealed class UiState {
@@ -135,6 +138,17 @@ class DetailViewModel @Inject constructor(
                         }
                     }
                 }
+        }
+    }
+
+    private fun logout() {
+        viewModelScope.launch {
+            tokenRepository.clearToken()
+            backOffWorkManager.clearWork()
+
+            _uiState.update {
+                UiState.Error(errorMessage = INVALID_TOKEN)
+            }
         }
     }
 }


### PR DESCRIPTION
notion - https://www.notion.so/refact-repository-118a26591b6180089a98f05424372fcb?pvs=4

# AS-IS

- 현재 토큰 만료, 연결 실패, 레파지토리가 존재하지 않는 에러들을 단순히 throwable.message 를 띄워주고 있다.

# TO-BE

```jsx
when (throwable) {
    is IOException -> {
        // errorMessage update
    }
    else -> {
        if (throwable.message?.contains("404") == true) {
            // 레파지토리가 존재하지 않을 때
            // errorMessage update

            return@onFailure
        }

        // 토큰이 만료되었을 때
        // 로그아웃 처리
    }
}
```

- 연결 실패했을 때, 토큰이 만료되었을 때, 레파지토리가 존재하지 않을 때 발생하는 에러들을 처리했다.