### PR TITLE
feat: DetailViewModel SideEffect sealed class 생성

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
@@ -104,6 +104,12 @@ class DetailActivity : AppCompatActivity() {
 
                 startActivity(intent)
             }
+            is SideEffect.StarClick -> {
+                viewModel.starRepository(repoDetailEntity)
+            }
+            is SideEffect.UnStarClick -> {
+                viewModel.unStarRepository(repoDetailEntity)
+            }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
@@ -132,8 +132,8 @@ class DetailActivity : AppCompatActivity() {
 
     private fun setOnStarClickListener(repoDetailEntity: RepoDetailEntity) {
         binding.ivStar.setOnClickListener {
-            if (repoDetailEntity.isStarred == true) viewModel.unStarRepository(repoDetailEntity)
-            else viewModel.starRepository(repoDetailEntity)
+            if (repoDetailEntity.isStarred == true) viewModel.setSideEffect(SideEffect.UnStarClick(repoDetailEntity))
+            else viewModel.setSideEffect(SideEffect.StarClick(repoDetailEntity))
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
@@ -14,6 +14,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.bumptech.glide.Glide
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.githubrepo.R
+import com.prac.githubrepo.constants.CONNECTION_FAIL
+import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.databinding.ActivityDetailBinding
 import com.prac.githubrepo.login.LoginActivity
 import com.prac.githubrepo.main.detail.DetailViewModel.UiState
@@ -86,7 +88,7 @@ class DetailActivity : AppCompatActivity() {
                         dialog.dismiss()
                     }
                     .setOnDismissListener {
-                        finish()
+                        handleDialogMessage(errorMessage)
                     }
                     .show()
             }
@@ -135,6 +137,15 @@ class DetailActivity : AppCompatActivity() {
             if (repoDetailEntity.isStarred == true) viewModel.setSideEffect(SideEffect.UnStarClick(repoDetailEntity))
             else viewModel.setSideEffect(SideEffect.StarClick(repoDetailEntity))
         }
+    }
+
+    private fun handleDialogMessage(dialogMessage: String) {
+        if (dialogMessage == CONNECTION_FAIL || dialogMessage == INVALID_REPOSITORY) {
+            viewModel.setSideEffect(SideEffect.BasicDialogDismiss)
+            return
+        }
+
+        viewModel.setSideEffect(SideEffect.LogoutDialogDismiss)
     }
 
     companion object {

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailActivity.kt
@@ -15,7 +15,9 @@ import com.bumptech.glide.Glide
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.githubrepo.R
 import com.prac.githubrepo.databinding.ActivityDetailBinding
+import com.prac.githubrepo.login.LoginActivity
 import com.prac.githubrepo.main.detail.DetailViewModel.UiState
+import com.prac.githubrepo.main.detail.DetailViewModel.SideEffect
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -42,6 +44,14 @@ class DetailActivity : AppCompatActivity() {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect {
                     it.handleUiState()
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.sideEffect.collect {
+                    it.handleSideEffect()
                 }
             }
         }
@@ -79,6 +89,20 @@ class DetailActivity : AppCompatActivity() {
                         finish()
                     }
                     .show()
+            }
+        }
+    }
+
+    private fun SideEffect.handleSideEffect() {
+        when (this) {
+            is SideEffect.BasicDialogDismiss -> {
+                finish()
+            }
+            is SideEffect.LogoutDialogDismiss -> {
+                val intent = Intent(this@DetailActivity, LoginActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK
+
+                startActivity(intent)
             }
         }
     }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -45,6 +45,8 @@ class DetailViewModel @Inject constructor(
     sealed class SideEffect {
         data object BasicDialogDismiss : SideEffect() // IOException, 404 에러의 alert dialog 가 dismiss 되는 경우
         data object LogoutDialogDismiss : SideEffect()
+        data class StarClick(val repoDetailEntity: RepoDetailEntity) : SideEffect()
+        data class UnStarClick(val repoDetailEntity: RepoDetailEntity) : SideEffect()
     }
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -13,7 +13,9 @@ import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -40,8 +42,22 @@ class DetailViewModel @Inject constructor(
         ) : UiState()
     }
 
+    sealed class SideEffect {
+        data object BasicDialogDismiss : SideEffect() // IOException, 404 에러의 alert dialog 가 dismiss 되는 경우
+        data object LogoutDialogDismiss : SideEffect()
+    }
+
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState: Flow<UiState> = _uiState.asStateFlow()
+
+    private val _sideEffect = MutableSharedFlow<SideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
+
+    fun setSideEffect(sideEffect: SideEffect) {
+        viewModelScope.launch {
+            _sideEffect.emit(sideEffect)
+        }
+    }
 
     fun getRepository(userName: String?, repoName: String?) {
         if (_uiState.value != UiState.Idle) return


### PR DESCRIPTION
notion - https://www.notion.so/feat-DetailViewModel-SideEffect-sealed-class-118a26591b61804d93b8c79e68dd5457?pvs=4

# AS-IS

- 현재 dialog dismiss, star, unstar 를 클릭했을 때 SideEffect 를 발행하기 위한 sealed class 및 변수가 존재하지 않는다.

# TO-BE

```jsx
sealed class SideEffect {
    data object BasicDialogDismiss : SideEffect() // IOException, 404 에러의 alert dialog 가 dismiss 되는 경우
    data object LogoutDialogDismiss : SideEffect()
    data class StarClick(val repoDetailEntity: RepoDetailEntity) : SideEffect()
    data class UnStarClick(val repoDetailEntity: RepoDetailEntity) : SideEffect()
}
```

- 현재 dialog dismiss, star, unstar 를 클릭했을 때 SideEffect 를 발행하기 위한 sealed class 생성