### PR TITLE
refact: auth 관련 error sealed class 생성 및 error handle 로직 변경

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/constants/ErrorMessage.kt
+++ b/app/src/main/java/com/prac/githubrepo/constants/ErrorMessage.kt
@@ -1,6 +1,12 @@
 package com.prac.githubrepo.constants
 
-const val LOGIN_FAIL = "로그인을 실패했습니다."
+// common
 const val CONNECTION_FAIL = "연결에 실패했습니다."
 const val INVALID_TOKEN = "토큰이 만료되었습니다. 다시 로그인해주세요."
+const val UNKNOWN = "알 수 없는 에러가 발생했습니다."
+
+// login
+const val LOGIN_FAIL = "로그인을 실패했습니다."
+
+// repository
 const val INVALID_REPOSITORY = "유효하지 않는 레파지토리입니다."

--- a/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
@@ -2,9 +2,11 @@ package com.prac.githubrepo.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.prac.data.exception.AuthException
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.LOGIN_FAIL
+import com.prac.githubrepo.constants.UNKNOWN
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -75,11 +77,14 @@ class LoginViewModel @Inject constructor(
                     setEvent(Event.Success)
                 }.onFailure {
                     when (it) {
-                        is IOException -> {
+                        is AuthException.NetworkError -> {
                             setUiState(UiState.Error(errorMessage = CONNECTION_FAIL))
                         }
-                        else -> {
+                        is AuthException.AuthorizationError -> {
                             setUiState(UiState.Error(errorMessage = LOGIN_FAIL))
+                        }
+                        else -> {
+                            setUiState(UiState.Error(errorMessage = UNKNOWN))
                         }
                     }
                 }
@@ -93,5 +98,4 @@ class LoginViewModel @Inject constructor(
             if (tokenRepository.isLoggedIn()) setEvent(Event.Success)
         }
     }
-
 }

--- a/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
@@ -76,17 +76,7 @@ class LoginViewModel @Inject constructor(
                 .onSuccess {
                     setEvent(Event.Success)
                 }.onFailure {
-                    when (it) {
-                        is AuthException.NetworkError -> {
-                            setUiState(UiState.Error(errorMessage = CONNECTION_FAIL))
-                        }
-                        is AuthException.AuthorizationError -> {
-                            setUiState(UiState.Error(errorMessage = LOGIN_FAIL))
-                        }
-                        else -> {
-                            setUiState(UiState.Error(errorMessage = UNKNOWN))
-                        }
-                    }
+                    handleLoginError(it)
                 }
         }
     }
@@ -96,6 +86,20 @@ class LoginViewModel @Inject constructor(
             if (uiState.value != UiState.Idle) return@launch
 
             if (tokenRepository.isLoggedIn()) setEvent(Event.Success)
+        }
+    }
+
+    private fun handleLoginError(t: Throwable) {
+        when (t) {
+            is AuthException.NetworkError -> {
+                setUiState(UiState.Error(errorMessage = CONNECTION_FAIL))
+            }
+            is AuthException.AuthorizationError -> {
+                setUiState(UiState.Error(errorMessage = LOGIN_FAIL))
+            }
+            else -> {
+                setUiState(UiState.Error(errorMessage = UNKNOWN))
+            }
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -5,12 +5,16 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.entity.RepoEntity
+import com.prac.data.exception.RepositoryException
 import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.constants.INVALID_TOKEN
+import com.prac.githubrepo.constants.UNKNOWN
 import com.prac.githubrepo.main.backoff.BackOffWorkManager
+import com.prac.githubrepo.main.detail.DetailViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -82,27 +86,7 @@ class MainViewModel @Inject constructor(
 
             repoRepository.starRepository(repoEntity.owner.login, repoEntity.name)
                 .onFailure {
-                    when (it) {
-                        is IOException -> {
-                            backOffWorkManager.addWork(
-                                uniqueID = "star_${repoEntity.id}",
-                                work = { repoRepository.starRepository(repoEntity.owner.login, repoEntity.name) }
-                            )
-                        }
-                        else -> {
-                            if (it.message?.contains("404") == true) {
-                                repoRepository.unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
-
-                                _uiState.update {
-                                    (it as UiState.Content).copy(dialogMessage = INVALID_REPOSITORY)
-                                }
-
-                                return@onFailure
-                            }
-
-                            logout()
-                        }
-                    }
+                    handleStarRepositoryFailure(it, repoEntity)
                 }
         }
     }
@@ -145,6 +129,28 @@ class MainViewModel @Inject constructor(
 
             _uiState.update {
                 (it as UiState.Content).copy(dialogMessage = INVALID_TOKEN)
+            }
+        }
+    }
+
+    private suspend fun handleStarRepositoryFailure(t: Throwable, repoEntity: RepoEntity) {
+        when (t) {
+            is RepositoryException.NetworkError -> {
+                backOffWorkManager.addWork(
+                    uniqueID = "star_${repoEntity.id}",
+                    work = { repoRepository.starRepository(repoEntity.owner.login, repoEntity.name) }
+                )
+            }
+            is RepositoryException.AuthorizationError -> {
+                logout()
+            }
+            is RepositoryException.NotFoundRepository -> {
+                repoRepository.unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
+
+                _uiState.update { (it as UiState.Content).copy(dialogMessage = INVALID_REPOSITORY) }
+            }
+            else -> {
+                _uiState.update { (it as UiState.Content).copy(dialogMessage = UNKNOWN) }
             }
         }
     }

--- a/data/src/main/java/com/prac/data/exception/AuthException.kt
+++ b/data/src/main/java/com/prac/data/exception/AuthException.kt
@@ -1,0 +1,9 @@
+package com.prac.data.exception
+
+sealed class AuthException : Exception() {
+    class NetworkError : AuthException()
+
+    class AuthorizationError : AuthException()
+
+    class UnKnownError : AuthException()
+}

--- a/data/src/main/java/com/prac/data/exception/RepositoryException.kt
+++ b/data/src/main/java/com/prac/data/exception/RepositoryException.kt
@@ -1,0 +1,11 @@
+package com.prac.data.exception
+
+sealed class RepositoryException :Exception() {
+    class NetworkError : RepositoryException()
+
+    class AuthorizationError : RepositoryException()
+
+    class NotFoundRepository : RepositoryException()
+
+    class UnKnownError : RepositoryException()
+}

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -86,7 +86,7 @@ internal class RepoRepositoryImpl @Inject constructor(
 
             Result.success(Unit)
         } catch (e: Exception) {
-            Result.failure(e)
+            handleRepositoryError(e)
         }
     }
 
@@ -96,7 +96,7 @@ internal class RepoRepositoryImpl @Inject constructor(
 
             Result.success(Unit)
         } catch (e: Exception) {
-            Result.failure(e)
+            handleRepositoryError(e)
         }
     }
 

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -11,6 +11,8 @@ import androidx.room.withTransaction
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.entity.RepoEntity
+import com.prac.data.exception.AuthException
+import com.prac.data.exception.RepositoryException
 import com.prac.data.repository.RepoRepository
 import com.prac.data.source.local.room.database.RepositoryDatabase
 import com.prac.data.source.local.room.entity.Owner
@@ -20,6 +22,8 @@ import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import retrofit2.HttpException
+import java.io.IOException
 import javax.inject.Inject
 
 internal class RepoRepositoryImpl @Inject constructor(
@@ -58,7 +62,7 @@ internal class RepoRepositoryImpl @Inject constructor(
                 )
             )
         } catch (e: Exception) {
-            Result.failure(e)
+            handleRepositoryError(e)
         }
     }
 
@@ -170,6 +174,20 @@ internal class RepoRepositoryImpl @Inject constructor(
             ?.let { repo ->
                 repositoryDatabase.remoteKeyDao().remoteKey(repo.id)
             }
+    }
+
+    private fun <T> handleRepositoryError(e: Exception): Result<T> {
+        return when (e) {
+            is HttpException -> {
+                when (e.code()) {
+                    401 -> Result.failure(RepositoryException.AuthorizationError())
+                    404 -> Result.failure(RepositoryException.NotFoundRepository())
+                    else -> Result.failure(AuthException.UnKnownError())
+                }
+            }
+            is IOException -> Result.failure(RepositoryException.NetworkError())
+            else -> Result.failure(AuthException.UnKnownError())
+        }
     }
 
     companion object {

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -49,6 +49,7 @@ internal class TokenRepositoryImpl @Inject constructor(
 
             Result.success(Unit)
         } catch (e: Exception) {
+            // 예외 발생 시 로그아웃 처리할 것이라서 따로 처리를 하지 않는다.
             Result.failure(e)
         }
     }


### PR DESCRIPTION
notion - https://www.notion.so/refact-auth-error-sealed-class-error-handle-11da26591b61803dbd43ea2bce2a6069?pvs=4

# AS-IS

- auth 관련 error 를 나타내는 명확한 구조가 없어 코드가 복잡하고 이해하기 어렵다.

# TO-BE

```jsx
sealed class AuthException : Exception() {
    class NetworkError : AuthException()

    class AuthorizationError : AuthException()

    class UnKnownError : AuthException()
}
```

- auth error 관련 sealed class 생성
- AuthException 을 통해서 error handle