### PR TITLE
refact: repository 관련 error sealed class 생성 및 error handle 로직 변경

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -5,12 +5,16 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.entity.RepoEntity
+import com.prac.data.exception.RepositoryException
 import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.constants.INVALID_TOKEN
+import com.prac.githubrepo.constants.UNKNOWN
 import com.prac.githubrepo.main.backoff.BackOffWorkManager
+import com.prac.githubrepo.main.detail.DetailViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -82,27 +86,7 @@ class MainViewModel @Inject constructor(
 
             repoRepository.starRepository(repoEntity.owner.login, repoEntity.name)
                 .onFailure {
-                    when (it) {
-                        is IOException -> {
-                            backOffWorkManager.addWork(
-                                uniqueID = "star_${repoEntity.id}",
-                                work = { repoRepository.starRepository(repoEntity.owner.login, repoEntity.name) }
-                            )
-                        }
-                        else -> {
-                            if (it.message?.contains("404") == true) {
-                                repoRepository.unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
-
-                                _uiState.update {
-                                    (it as UiState.Content).copy(dialogMessage = INVALID_REPOSITORY)
-                                }
-
-                                return@onFailure
-                            }
-
-                            logout()
-                        }
-                    }
+                    handleStarRepositoryFailure(it, repoEntity)
                 }
         }
     }
@@ -145,6 +129,28 @@ class MainViewModel @Inject constructor(
 
             _uiState.update {
                 (it as UiState.Content).copy(dialogMessage = INVALID_TOKEN)
+            }
+        }
+    }
+
+    private suspend fun handleStarRepositoryFailure(t: Throwable, repoEntity: RepoEntity) {
+        when (t) {
+            is RepositoryException.NetworkError -> {
+                backOffWorkManager.addWork(
+                    uniqueID = "star_${repoEntity.id}",
+                    work = { repoRepository.starRepository(repoEntity.owner.login, repoEntity.name) }
+                )
+            }
+            is RepositoryException.AuthorizationError -> {
+                logout()
+            }
+            is RepositoryException.NotFoundRepository -> {
+                repoRepository.unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
+
+                _uiState.update { (it as UiState.Content).copy(dialogMessage = INVALID_REPOSITORY) }
+            }
+            else -> {
+                _uiState.update { (it as UiState.Content).copy(dialogMessage = UNKNOWN) }
             }
         }
     }

--- a/data/src/main/java/com/prac/data/exception/RepositoryException.kt
+++ b/data/src/main/java/com/prac/data/exception/RepositoryException.kt
@@ -1,0 +1,11 @@
+package com.prac.data.exception
+
+sealed class RepositoryException :Exception() {
+    class NetworkError : RepositoryException()
+
+    class AuthorizationError : RepositoryException()
+
+    class NotFoundRepository : RepositoryException()
+
+    class UnKnownError : RepositoryException()
+}

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -86,7 +86,7 @@ internal class RepoRepositoryImpl @Inject constructor(
 
             Result.success(Unit)
         } catch (e: Exception) {
-            Result.failure(e)
+            handleRepositoryError(e)
         }
     }
 
@@ -96,7 +96,7 @@ internal class RepoRepositoryImpl @Inject constructor(
 
             Result.success(Unit)
         } catch (e: Exception) {
-            Result.failure(e)
+            handleRepositoryError(e)
         }
     }
 

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -11,6 +11,8 @@ import androidx.room.withTransaction
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.entity.RepoEntity
+import com.prac.data.exception.AuthException
+import com.prac.data.exception.RepositoryException
 import com.prac.data.repository.RepoRepository
 import com.prac.data.source.local.room.database.RepositoryDatabase
 import com.prac.data.source.local.room.entity.Owner
@@ -20,6 +22,8 @@ import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import retrofit2.HttpException
+import java.io.IOException
 import javax.inject.Inject
 
 internal class RepoRepositoryImpl @Inject constructor(
@@ -58,7 +62,7 @@ internal class RepoRepositoryImpl @Inject constructor(
                 )
             )
         } catch (e: Exception) {
-            Result.failure(e)
+            handleRepositoryError(e)
         }
     }
 
@@ -170,6 +174,20 @@ internal class RepoRepositoryImpl @Inject constructor(
             ?.let { repo ->
                 repositoryDatabase.remoteKeyDao().remoteKey(repo.id)
             }
+    }
+
+    private fun <T> handleRepositoryError(e: Exception): Result<T> {
+        return when (e) {
+            is HttpException -> {
+                when (e.code()) {
+                    401 -> Result.failure(RepositoryException.AuthorizationError())
+                    404 -> Result.failure(RepositoryException.NotFoundRepository())
+                    else -> Result.failure(AuthException.UnKnownError())
+                }
+            }
+            is IOException -> Result.failure(RepositoryException.NetworkError())
+            else -> Result.failure(AuthException.UnKnownError())
+        }
     }
 
     companion object {


### PR DESCRIPTION
notion - https://www.notion.so/refact-repository-error-sealed-class-error-handle-11da26591b618048b6befccb40a38de5?pvs=4

# AS-IS

- repository 관련 error 를 나타내는 명확한 구조가 없어 코드가 복잡하고 이해하기 어렵다.

# TO-BE

```jsx
sealed class RepositoryException :Exception() {
    class NetworkError : RepositoryException()

    class AuthorizationError : RepositoryException()

    class NotFoundRepository : RepositoryException()

    class UnKnownError : RepositoryException()
}
```

- repository error 관련 sealed class 생성
- RepositoryException 을 통해서 error handle