### PR TITLE
refact: exception sealed class 변경

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,12 +63,15 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     testImplementation(libs.junit)
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 
     implementation(project(":data"))
 
     implementation(libs.jetbrains.kotlinx.coroutines)
+    implementation(libs.jetbrains.kotlinx.coroutines.test)
 
     implementation(libs.glide)
 

--- a/app/src/main/java/com/prac/githubrepo/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/di/BackOffModule.kt
@@ -1,7 +1,7 @@
-package com.prac.githubrepo.main.di
+package com.prac.githubrepo.di
 
 import com.prac.data.exception.CommonException
-import com.prac.githubrepo.main.backoff.BackOffWorkManager
+import com.prac.githubrepo.util.BackOffWorkManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -12,9 +12,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import java.io.IOException
 import javax.inject.Singleton
-import kotlin.math.pow
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/com/prac/githubrepo/di/DispatchersAnnotation.kt
+++ b/app/src/main/java/com/prac/githubrepo/di/DispatchersAnnotation.kt
@@ -1,0 +1,7 @@
+package com.prac.githubrepo.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.RUNTIME)
+annotation class IODispatcher

--- a/app/src/main/java/com/prac/githubrepo/di/DispatchersModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/di/DispatchersModule.kt
@@ -1,0 +1,18 @@
+package com.prac.githubrepo.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class DispatchersModule {
+    @Provides
+    @Singleton
+    @IODispatcher
+    fun providesIODispatcher(): CoroutineDispatcher = Dispatchers.IO
+}

--- a/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
@@ -7,7 +7,9 @@ import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.LOGIN_FAIL
 import com.prac.githubrepo.constants.UNKNOWN
+import com.prac.githubrepo.di.IODispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,7 +21,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val tokenRepository: TokenRepository
+    private val tokenRepository: TokenRepository,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ): ViewModel() {
     sealed class UiState {
         data object Idle : UiState()
@@ -66,7 +69,7 @@ class LoginViewModel @Inject constructor(
     }
 
     fun loginWithGitHub(code: String) {
-        viewModelScope.launch {
+        viewModelScope.launch(ioDispatcher) {
             if (uiState.value != UiState.Idle) return@launch
 
             setUiState(UiState.Loading)
@@ -81,7 +84,7 @@ class LoginViewModel @Inject constructor(
     }
 
     private fun checkAutoLogin() {
-        viewModelScope.launch {
+        viewModelScope.launch(ioDispatcher) {
             if (uiState.value != UiState.Idle) return@launch
 
             if (tokenRepository.isLoggedIn()) setEvent(Event.Success)

--- a/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
@@ -2,7 +2,7 @@ package com.prac.githubrepo.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.prac.data.exception.AuthException
+import com.prac.data.exception.CommonException
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.LOGIN_FAIL
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -91,10 +90,10 @@ class LoginViewModel @Inject constructor(
 
     private fun handleLoginError(t: Throwable) {
         when (t) {
-            is AuthException.NetworkError -> {
+            is CommonException.NetworkError -> {
                 setUiState(UiState.Error(errorMessage = CONNECTION_FAIL))
             }
-            is AuthException.AuthorizationError -> {
+            is CommonException.AuthorizationError -> {
                 setUiState(UiState.Error(errorMessage = LOGIN_FAIL))
             }
             else -> {

--- a/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
@@ -60,7 +60,7 @@ class LoginViewModel @Inject constructor(
         _uiState.update { uiState }
     }
 
-    fun setEvent(event: Event) {
+    private fun setEvent(event: Event) {
         viewModelScope.launch {
             _event.emit(event)
         }

--- a/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/login/LoginViewModel.kt
@@ -46,10 +46,10 @@ class LoginViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
 
-    private val _event = MutableSharedFlow<Event>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val _event = MutableSharedFlow<Event>()
     val event = _event.asSharedFlow()
 
-    private val _sideEffect = MutableSharedFlow<SideEffect>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val _sideEffect = MutableSharedFlow<SideEffect>()
     val sideEffect = _sideEffect.asSharedFlow()
 
     init {
@@ -61,11 +61,15 @@ class LoginViewModel @Inject constructor(
     }
 
     fun setEvent(event: Event) {
-        _event.tryEmit(event)
+        viewModelScope.launch {
+            _event.emit(event)
+        }
     }
 
     fun setSideEffect(sideEffect: SideEffect) {
-        _sideEffect.tryEmit(sideEffect)
+        viewModelScope.launch {
+            _sideEffect.emit(sideEffect)
+        }
     }
 
     fun loginWithGitHub(code: String) {

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 mainAdapter.loadStateFlow.collect {
-                    it.handleLoadStates()
+                    viewModel.handleLoadStates(it)
                 }
             }
         }
@@ -88,31 +88,6 @@ class MainActivity : AppCompatActivity() {
                 }
             }
         }
-    }
-
-    private fun CombinedLoadStates.handleLoadStates() {
-        if (refresh is LoadState.Error) {
-            if ((refresh as LoadState.Error).error !is IOException) {
-                viewModel.logout()
-                return
-            }
-            viewModel.updateLoadState(refresh)
-        }
-
-        if (refresh is LoadState.Loading) {
-            viewModel.updateLoadState(refresh)
-            return
-        }
-
-        if (append is LoadState.Error) {
-             if ((append as LoadState.Error).error !is IOException) {
-                viewModel.logout()
-                return
-            }
-            viewModel.updateLoadState(append)
-        }
-
-        viewModel.updateLoadState(append)
     }
 
     private suspend fun UiState.handleUiState() {

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -6,6 +6,7 @@ import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import com.prac.data.entity.RepoEntity
+import com.prac.data.exception.CommonException
 import com.prac.data.exception.RepositoryException
 import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
@@ -21,7 +22,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -113,13 +113,13 @@ class MainViewModel @Inject constructor(
 
     private suspend fun handleStarRepositoryFailure(t: Throwable, repoEntity: RepoEntity) {
         when (t) {
-            is RepositoryException.NetworkError -> {
+            is CommonException.NetworkError -> {
                 backOffWorkManager.addWork(
                     uniqueID = "star_${repoEntity.id}",
                     work = { repoRepository.starRepository(repoEntity.owner.login, repoEntity.name) }
                 )
             }
-            is RepositoryException.AuthorizationError -> {
+            is CommonException.AuthorizationError -> {
                 logout()
             }
             is RepositoryException.NotFoundRepository -> {
@@ -135,13 +135,13 @@ class MainViewModel @Inject constructor(
 
     private suspend fun handleUnStarRepositoryFailure(t: Throwable, repoEntity: RepoEntity) {
         when (t) {
-            is RepositoryException.NetworkError -> {
+            is CommonException.NetworkError -> {
                 backOffWorkManager.addWork(
                     uniqueID = "star_${repoEntity.id}",
                     work = { repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name) }
                 )
             }
-            is RepositoryException.AuthorizationError -> {
+            is CommonException.AuthorizationError -> {
                 logout()
             }
             is RepositoryException.NotFoundRepository -> {

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -13,9 +13,10 @@ import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.constants.UNKNOWN
+import com.prac.githubrepo.di.IODispatcher
 import com.prac.githubrepo.util.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -28,7 +29,8 @@ import javax.inject.Inject
 class MainViewModel @Inject constructor(
     private val repoRepository: RepoRepository,
     private val tokenRepository: TokenRepository,
-    private val backOffWorkManager: BackOffWorkManager
+    private val backOffWorkManager: BackOffWorkManager,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ): ViewModel() {
     sealed class UiState {
         data object Idle : UiState()
@@ -79,7 +81,7 @@ class MainViewModel @Inject constructor(
     }
 
     fun starRepository(repoEntity: RepoEntity) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             repoRepository.starLocalRepository(repoEntity.id, repoEntity.stargazersCount + 1)
 
             repoRepository.starRepository(repoEntity.owner.login, repoEntity.name)
@@ -90,7 +92,7 @@ class MainViewModel @Inject constructor(
     }
 
     fun unStarRepository(repoEntity: RepoEntity) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             repoRepository.unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount - 1)
 
             repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name)

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -107,7 +107,9 @@ class MainViewModel @Inject constructor(
     fun handleLoadStates(combinedLoadStates: CombinedLoadStates) {
         if (combinedLoadStates.refresh is LoadState.Error) {
             if ((combinedLoadStates.refresh as LoadState.Error).error !is IOException) {
-                logout()
+                viewModelScope.launch(ioDispatcher) {
+                    logout()
+                }
                 return
             }
             updateLoadState(combinedLoadStates.refresh)
@@ -120,7 +122,9 @@ class MainViewModel @Inject constructor(
 
         if (combinedLoadStates.append is LoadState.Error) {
             if ((combinedLoadStates.append as LoadState.Error).error !is IOException) {
-                logout()
+                viewModelScope.launch(ioDispatcher) {
+                    logout()
+                }
                 return
             }
             updateLoadState(combinedLoadStates.append)
@@ -129,14 +133,12 @@ class MainViewModel @Inject constructor(
         updateLoadState(combinedLoadStates.append)
     }
 
-    private fun logout() {
-        viewModelScope.launch {
-            tokenRepository.clearToken()
-            backOffWorkManager.clearWork()
+    private suspend fun logout() {
+        tokenRepository.clearToken()
+        backOffWorkManager.clearWork()
 
-            _uiState.update {
-                (it as UiState.Content).copy(dialogMessage = INVALID_TOKEN)
-            }
+        _uiState.update {
+            (it as UiState.Content).copy(dialogMessage = INVALID_TOKEN)
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -13,7 +13,7 @@ import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.constants.UNKNOWN
-import com.prac.githubrepo.main.backoff.BackOffWorkManager
+import com.prac.githubrepo.util.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -157,6 +157,8 @@ class MainViewModel @Inject constructor(
                 _uiState.update { (it as UiState.Content).copy(dialogMessage = INVALID_REPOSITORY) }
             }
             else -> {
+                repoRepository.unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
+
                 _uiState.update { (it as UiState.Content).copy(dialogMessage = UNKNOWN) }
             }
         }
@@ -179,6 +181,8 @@ class MainViewModel @Inject constructor(
                 _uiState.update { (it as UiState.Content).copy(dialogMessage = INVALID_REPOSITORY) }
             }
             else -> {
+                repoRepository.starLocalRepository(repoEntity.id, repoEntity.stargazersCount)
+
                 _uiState.update { (it as UiState.Content).copy(dialogMessage = UNKNOWN) }
             }
         }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -3,6 +3,7 @@ package com.prac.githubrepo.main.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.prac.data.entity.RepoDetailEntity
+import com.prac.data.exception.CommonException
 import com.prac.data.exception.RepositoryException
 import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
@@ -10,7 +11,6 @@ import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.constants.UNKNOWN
-import com.prac.githubrepo.main.MainViewModel
 import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -142,10 +141,10 @@ class DetailViewModel @Inject constructor(
 
     private fun handleGetRepositoryFailure(t: Throwable) {
         when (t) {
-            is RepositoryException.NetworkError -> {
+            is CommonException.NetworkError -> {
                 _uiState.update { UiState.Error(errorMessage = CONNECTION_FAIL) }
             }
-            is RepositoryException.AuthorizationError -> {
+            is CommonException.AuthorizationError -> {
                 logout()
             }
             is RepositoryException.NotFoundRepository -> {
@@ -159,13 +158,13 @@ class DetailViewModel @Inject constructor(
 
     private suspend fun handleStarRepositoryFailure(t: Throwable, repoDetailEntity: RepoDetailEntity) {
         when (t) {
-            is RepositoryException.NetworkError -> {
+            is CommonException.NetworkError -> {
                 backOffWorkManager.addWork(
                     uniqueID = "star_${repoDetailEntity.id}",
                     work = { repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name) }
                 )
             }
-            is RepositoryException.AuthorizationError -> {
+            is CommonException.AuthorizationError -> {
                 logout()
             }
             is RepositoryException.NotFoundRepository -> {
@@ -181,13 +180,13 @@ class DetailViewModel @Inject constructor(
 
     private suspend fun handleUnStarRepositoryFailure(t: Throwable, repoDetailEntity: RepoDetailEntity) {
         when (t) {
-            is RepositoryException.NetworkError -> {
+            is CommonException.NetworkError -> {
                 backOffWorkManager.addWork(
                     uniqueID = "star_${repoDetailEntity.id}",
                     work = { repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name) }
                 )
             }
-            is RepositoryException.AuthorizationError -> {
+            is CommonException.AuthorizationError -> {
                 logout()
             }
             is RepositoryException.NotFoundRepository -> {

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -107,14 +107,12 @@ class DetailViewModel @Inject constructor(
         }
     }
 
-    private fun logout() {
-        viewModelScope.launch {
-            tokenRepository.clearToken()
-            backOffWorkManager.clearWork()
+    private suspend fun logout() {
+        tokenRepository.clearToken()
+        backOffWorkManager.clearWork()
 
-            _uiState.update {
-                UiState.Error(errorMessage = INVALID_TOKEN)
-            }
+        _uiState.update {
+            UiState.Error(errorMessage = INVALID_TOKEN)
         }
     }
 
@@ -141,7 +139,7 @@ class DetailViewModel @Inject constructor(
         }
     }
 
-    private fun handleGetRepositoryFailure(t: Throwable) {
+    private suspend fun handleGetRepositoryFailure(t: Throwable) {
         when (t) {
             is CommonException.NetworkError -> {
                 _uiState.update { UiState.Error(errorMessage = CONNECTION_FAIL) }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -11,7 +11,7 @@ import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.constants.UNKNOWN
-import com.prac.githubrepo.main.backoff.BackOffWorkManager
+import com.prac.githubrepo.util.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -11,9 +11,10 @@ import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.constants.UNKNOWN
+import com.prac.githubrepo.di.IODispatcher
 import com.prac.githubrepo.util.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,7 +28,8 @@ import javax.inject.Inject
 class DetailViewModel @Inject constructor(
     private val repoRepository: RepoRepository,
     private val tokenRepository: TokenRepository,
-    private val backOffWorkManager: BackOffWorkManager
+    private val backOffWorkManager: BackOffWorkManager,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ViewModel() {
     sealed class UiState {
         data object Idle : UiState()
@@ -72,7 +74,7 @@ class DetailViewModel @Inject constructor(
             return
         }
 
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             repoRepository.getRepository(userName, repoName)
                 .onSuccess {
                     handleGetRepositorySuccess(it)
@@ -84,7 +86,7 @@ class DetailViewModel @Inject constructor(
     }
 
     fun starRepository(repoDetailEntity: RepoDetailEntity) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             repoRepository.starLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount + 1)
 
             repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
@@ -95,7 +97,7 @@ class DetailViewModel @Inject constructor(
     }
 
     fun unStarRepository(repoDetailEntity: RepoDetailEntity) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch(ioDispatcher) {
             repoRepository.unStarLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount - 1)
 
             repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name)

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -53,7 +53,7 @@ class DetailViewModel @Inject constructor(
     }
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
-    val uiState: Flow<UiState> = _uiState.asStateFlow()
+    val uiState = _uiState.asStateFlow()
 
     private val _sideEffect = MutableSharedFlow<SideEffect>()
     val sideEffect = _sideEffect.asSharedFlow()

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -173,6 +173,8 @@ class DetailViewModel @Inject constructor(
                 _uiState.update { UiState.Error(errorMessage = INVALID_REPOSITORY) }
             }
             else -> {
+                repoRepository.unStarLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount)
+
                 _uiState.update { UiState.Error(errorMessage = UNKNOWN) }
             }
         }
@@ -195,6 +197,8 @@ class DetailViewModel @Inject constructor(
                 _uiState.update { UiState.Error(errorMessage = INVALID_REPOSITORY) }
             }
             else -> {
+                repoRepository.starLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount)
+
                 _uiState.update { UiState.Error(errorMessage = UNKNOWN) }
             }
         }

--- a/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
@@ -1,5 +1,6 @@
 package com.prac.githubrepo.main.di
 
+import com.prac.data.exception.CommonException
 import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.Module
 import dagger.Provides
@@ -46,7 +47,7 @@ class BackOffModule {
                                 return@launch
                             }
                             .onFailure {
-                                if (it !is IOException) {
+                                if (it !is CommonException) {
                                     cancelAndRemoveJob(uniqueID)
                                     return@launch
                                 }

--- a/app/src/main/java/com/prac/githubrepo/util/BackOffWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/util/BackOffWorkManager.kt
@@ -1,4 +1,4 @@
-package com.prac.githubrepo.main.backoff
+package com.prac.githubrepo.util
 
 interface BackOffWorkManager {
     fun addWork(

--- a/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
@@ -2,7 +2,9 @@ package com.prac.githubrepo.login
 
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.util.StandardTestDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
@@ -31,5 +33,18 @@ class LoginViewModelTest {
         val result = loginViewModel.event.first()
 
         Assert.assertTrue(result is LoginViewModel.Event.Success)
+    }
+
+    @Test
+    fun loginWithGitHub_success_eventSuccess() = runTest {
+        val code = "code"
+        whenever(tokenRepository.isLoggedIn()).thenReturn(false)
+        loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
+        whenever(tokenRepository.authorizeOAuth(code)).thenReturn(Result.success(Unit))
+
+        loginViewModel.loginWithGitHub(code)
+
+        val event = loginViewModel.event.first()
+        Assert.assertTrue(event is LoginViewModel.Event.Success)
     }
 }

--- a/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
@@ -3,13 +3,12 @@ package com.prac.githubrepo.login
 import com.prac.data.exception.CommonException
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.CONNECTION_FAIL
-import com.prac.githubrepo.main.MainViewModel
+import com.prac.githubrepo.constants.LOGIN_FAIL
 import com.prac.githubrepo.util.StandardTestDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -67,5 +66,20 @@ class LoginViewModelTest {
         val uiState = loginViewModel.uiState.first()
         assertTrue(uiState is LoginViewModel.UiState.Error)
         assertEquals((uiState as LoginViewModel.UiState.Error).errorMessage, CONNECTION_FAIL)
+    }
+
+    @Test
+    fun loginWithGitHub_authorizationError() = runTest {
+        val code = "code"
+        whenever(tokenRepository.isLoggedIn()).thenReturn(false)
+        loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
+        whenever(tokenRepository.authorizeOAuth(code)).thenReturn(Result.failure(CommonException.AuthorizationError()))
+
+        loginViewModel.loginWithGitHub(code)
+        advanceUntilIdle()
+
+        val uiState = loginViewModel.uiState.first()
+        assertTrue(uiState is LoginViewModel.UiState.Error)
+        assertEquals((uiState as LoginViewModel.UiState.Error).errorMessage, LOGIN_FAIL)
     }
 }

--- a/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
@@ -4,6 +4,7 @@ import com.prac.data.exception.CommonException
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.LOGIN_FAIL
+import com.prac.githubrepo.constants.UNKNOWN
 import com.prac.githubrepo.util.StandardTestDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -81,5 +82,20 @@ class LoginViewModelTest {
         val uiState = loginViewModel.uiState.first()
         assertTrue(uiState is LoginViewModel.UiState.Error)
         assertEquals((uiState as LoginViewModel.UiState.Error).errorMessage, LOGIN_FAIL)
+    }
+
+    @Test
+    fun loginWithGitHub_unknownError() = runTest {
+        val code = "code"
+        whenever(tokenRepository.isLoggedIn()).thenReturn(false)
+        loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
+        whenever(tokenRepository.authorizeOAuth(code)).thenReturn(Result.failure(CommonException.UnKnownError()))
+
+        loginViewModel.loginWithGitHub(code)
+        advanceUntilIdle()
+
+        val uiState = loginViewModel.uiState.first()
+        assertTrue(uiState is LoginViewModel.UiState.Error)
+        assertEquals((uiState as LoginViewModel.UiState.Error).errorMessage, UNKNOWN)
     }
 }

--- a/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
@@ -1,12 +1,17 @@
 package com.prac.githubrepo.login
 
+import com.prac.data.exception.CommonException
 import com.prac.data.repository.TokenRepository
+import com.prac.githubrepo.constants.CONNECTION_FAIL
+import com.prac.githubrepo.main.MainViewModel
 import com.prac.githubrepo.util.StandardTestDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -14,6 +19,7 @@ import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.whenever
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
 class LoginViewModelTest {
 
@@ -32,7 +38,7 @@ class LoginViewModelTest {
 
         val result = loginViewModel.event.first()
 
-        Assert.assertTrue(result is LoginViewModel.Event.Success)
+        assertTrue(result is LoginViewModel.Event.Success)
     }
 
     @Test
@@ -45,6 +51,21 @@ class LoginViewModelTest {
         loginViewModel.loginWithGitHub(code)
 
         val event = loginViewModel.event.first()
-        Assert.assertTrue(event is LoginViewModel.Event.Success)
+        assertTrue(event is LoginViewModel.Event.Success)
+    }
+
+    @Test
+    fun loginWithGitHub_networkError() = runTest {
+        val code = "code"
+        whenever(tokenRepository.isLoggedIn()).thenReturn(false)
+        loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
+        whenever(tokenRepository.authorizeOAuth(code)).thenReturn(Result.failure(CommonException.NetworkError()))
+
+        loginViewModel.loginWithGitHub(code)
+        advanceUntilIdle()
+
+        val uiState = loginViewModel.uiState.first()
+        assertTrue(uiState is LoginViewModel.UiState.Error)
+        assertEquals((uiState as LoginViewModel.UiState.Error).errorMessage, CONNECTION_FAIL)
     }
 }

--- a/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
@@ -2,10 +2,15 @@ package com.prac.githubrepo.login
 
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.util.StandardTestDispatcherRule
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
 class LoginViewModelTest {
@@ -17,4 +22,14 @@ class LoginViewModelTest {
     private lateinit var tokenRepository: TokenRepository
 
     private lateinit var loginViewModel: LoginViewModel
+
+    @Test
+    fun checkAutoLogin_userIsLoggedIn_eventSuccess() = runTest {
+        whenever(tokenRepository.isLoggedIn()).thenReturn(true)
+        loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
+
+        val result = loginViewModel.event.first()
+
+        Assert.assertTrue(result is LoginViewModel.Event.Success)
+    }
 }

--- a/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
@@ -1,0 +1,20 @@
+package com.prac.githubrepo.login
+
+import com.prac.data.repository.TokenRepository
+import com.prac.githubrepo.util.StandardTestDispatcherRule
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class LoginViewModelTest {
+
+    @get:Rule
+    val standardTestDispatcherRule = StandardTestDispatcherRule()
+
+    @Mock
+    private lateinit var tokenRepository: TokenRepository
+
+    private lateinit var loginViewModel: LoginViewModel
+}

--- a/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
@@ -170,6 +170,21 @@ class MainViewModelTest {
         verify(repoRepository).unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
     }
 
+    @Test
+    fun unStarRepository_repositoryIsNotFoundError_updateUiStateDialogMessage() = runTest {
+        val repoEntity = makeRepoEntity()
+        whenever(repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name))
+            .thenReturn(Result.failure(RepositoryException.NotFoundRepository()))
+
+        mainViewModel.unStarRepository(repoEntity)
+        advanceUntilIdle()
+
+        val uiState = mainViewModel.uiState.value
+        Assert.assertTrue(uiState is MainViewModel.UiState.Content)
+        Assert.assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, INVALID_REPOSITORY)
+        verify(repoRepository).unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun starRepository_unKnownError_updateUiStateDialogMessage() = runTest {

--- a/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
@@ -141,6 +141,21 @@ class MainViewModelTest {
     }
 
     @Test
+    fun unStarRepository_authorizationError_updateUiStateDialogMessage() = runTest {
+        val repoEntity = makeRepoEntity()
+        whenever(repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name))
+            .thenReturn(Result.failure(CommonException.AuthorizationError()))
+
+        mainViewModel.unStarRepository(repoEntity)
+        advanceUntilIdle()
+
+        val uiState = mainViewModel.uiState.value
+        Assert.assertTrue(uiState is MainViewModel.UiState.Content)
+        Assert.assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, INVALID_TOKEN)
+        verify(tokenRepository).clearToken()
+    }
+
+    @Test
     fun starRepository_repositoryIsNotFoundError_updateUiStateDialogMessage() = runTest {
         val repoEntity = makeRepoEntity()
         whenever(repoRepository.starRepository(repoEntity.owner.login, repoEntity.name))

--- a/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
@@ -201,6 +201,22 @@ class MainViewModelTest {
         verify(repoRepository).unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun unStarRepository_unKnownError_updateUiStateDialogMessage() = runTest {
+        val repoEntity = makeRepoEntity()
+        whenever(repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name))
+            .thenReturn(Result.failure(CommonException.UnKnownError()))
+
+        mainViewModel.unStarRepository(repoEntity)
+        advanceUntilIdle()
+
+        val uiState = mainViewModel.uiState.value
+        Assert.assertTrue(uiState is MainViewModel.UiState.Content)
+        Assert.assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, UNKNOWN)
+        verify(repoRepository).unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
+    }
+
     private fun makeRepoEntity() =
         RepoEntity(
             id = 1,

--- a/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
@@ -1,0 +1,45 @@
+package com.prac.githubrepo.main
+
+import androidx.paging.PagingData
+import com.prac.data.entity.RepoEntity
+import com.prac.data.repository.RepoRepository
+import com.prac.data.repository.TokenRepository
+import com.prac.githubrepo.util.FakeBackOffWorkManager
+import com.prac.githubrepo.util.StandardTestDispatcherRule
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
+
+@RunWith(MockitoJUnitRunner::class)
+class MainViewModelTest {
+
+    @get:Rule
+    val standardTestDispatcherRule = StandardTestDispatcherRule()
+
+    @Mock private lateinit var tokenRepository: TokenRepository
+    @Mock private lateinit var repoRepository: RepoRepository
+    private lateinit var backOffWork: FakeBackOffWorkManager
+
+    private lateinit var mainViewModel: MainViewModel
+
+    @Before
+    fun setUp() = runTest {
+        backOffWork = FakeBackOffWorkManager()
+
+        val pagingData = PagingData.from(emptyList<RepoEntity>())
+        whenever(repoRepository.getRepositories()).thenReturn(flow { emit(pagingData) } )
+        mainViewModel = MainViewModel(repoRepository, tokenRepository, backOffWork, standardTestDispatcherRule.testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        backOffWork.clearWork()
+        backOffWork.clearDelayTimes()
+    }
+}

--- a/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.prac.githubrepo.main
 
 import androidx.paging.PagingData
+import app.cash.turbine.test
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.data.exception.CommonException
@@ -9,6 +10,7 @@ import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.constants.INVALID_TOKEN
+import com.prac.githubrepo.constants.UNKNOWN
 import com.prac.githubrepo.util.FakeBackOffWorkManager
 import com.prac.githubrepo.util.StandardTestDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -122,6 +124,22 @@ class MainViewModelTest {
         val uiState = mainViewModel.uiState.value
         Assert.assertTrue(uiState is MainViewModel.UiState.Content)
         Assert.assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, INVALID_REPOSITORY)
+        verify(repoRepository).unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun starRepository_unKnownError_updateUiStateDialogMessage() = runTest {
+        val repoEntity = makeRepoEntity()
+        whenever(repoRepository.starRepository(repoEntity.owner.login, repoEntity.name))
+            .thenReturn(Result.failure(CommonException.UnKnownError()))
+
+        mainViewModel.starRepository(repoEntity)
+        advanceUntilIdle()
+
+        val uiState = mainViewModel.uiState.value
+        Assert.assertTrue(uiState is MainViewModel.UiState.Content)
+        Assert.assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, UNKNOWN)
         verify(repoRepository).unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
     }
 

--- a/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
@@ -7,10 +7,13 @@ import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.util.FakeBackOffWorkManager
 import com.prac.githubrepo.util.StandardTestDispatcherRule
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
@@ -41,5 +44,14 @@ class MainViewModelTest {
     fun tearDown() {
         backOffWork.clearWork()
         backOffWork.clearDelayTimes()
+    }
+
+    @Test
+    fun getRepositories_updateUiStateToContent() = runTest {
+        advanceUntilIdle()
+
+        val result = mainViewModel.uiState.value
+
+        Assert.assertTrue(result is MainViewModel.UiState.Content)
     }
 }

--- a/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.prac.githubrepo.main
 
 import androidx.paging.PagingData
+import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
@@ -17,6 +18,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @RunWith(MockitoJUnitRunner::class)
@@ -54,4 +56,28 @@ class MainViewModelTest {
 
         Assert.assertTrue(result is MainViewModel.UiState.Content)
     }
+
+    @Test
+    fun starRepository_success_callStarLocalAndRemoteRepository() = runTest {
+        val repoEntity = makeRepoEntity()
+        whenever(repoRepository.starRepository(repoEntity.owner.login, repoEntity.name))
+            .thenReturn(Result.success(Unit))
+
+        mainViewModel.starRepository(repoEntity)
+        advanceUntilIdle()
+
+        verify(repoRepository).starLocalRepository(repoEntity.id, repoEntity.stargazersCount + 1)
+        verify(repoRepository).starRepository(repoEntity.owner.login, repoEntity.name)
+    }
+
+    private fun makeRepoEntity() =
+        RepoEntity(
+            id = 1,
+            name = "name",
+            owner = OwnerEntity(login = "login", avatarUrl = "avatarUrl"),
+            stargazersCount = 10,
+            updatedAt = "updatedAt",
+            isStarred = null
+        )
+
 }

--- a/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.prac.githubrepo.main
 
 import androidx.paging.PagingData
-import app.cash.turbine.test
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.data.exception.CommonException
@@ -77,6 +76,17 @@ class MainViewModelTest {
 
         verify(repoRepository).starLocalRepository(repoEntity.id, repoEntity.stargazersCount + 1)
         verify(repoRepository).starRepository(repoEntity.owner.login, repoEntity.name)
+    }
+
+    @Test
+    fun unStarRepository_success_callStarLocalAndRemoteRepository() = runTest {
+        val repoEntity = makeRepoEntity()
+
+        mainViewModel.unStarRepository(repoEntity)
+        advanceUntilIdle()
+
+        verify(repoRepository).unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount - 1)
+        verify(repoRepository).unStarRepository(repoEntity.owner.login, repoEntity.name)
     }
 
     @Test

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -9,6 +9,7 @@ import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.constants.INVALID_TOKEN
+import com.prac.githubrepo.constants.UNKNOWN
 import com.prac.githubrepo.util.FakeBackOffWorkManager
 import com.prac.githubrepo.util.StandardTestDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -238,6 +239,21 @@ class DetailViewModelTest {
         assertTrue(uiState is DetailViewModel.UiState.Error)
         assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, INVALID_REPOSITORY)
         verify(repoRepository).starLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount)
+    }
+
+    @Test
+    fun starRepository_unKnownError_updateUiStateToError() = runTest {
+        val repoDetailEntity = makeRepoDetailEntity()
+        whenever(repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name))
+            .thenReturn(Result.failure(CommonException.UnKnownError()))
+
+        detailViewMock.starRepository(repoDetailEntity)
+        advanceUntilIdle()
+
+        val uiState = detailViewMock.uiState.value
+        assertTrue(uiState is DetailViewModel.UiState.Error)
+        assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, UNKNOWN)
+        verify(repoRepository).unStarLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount)
     }
 
     private fun makeRepoDetailEntity() =

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -256,6 +256,21 @@ class DetailViewModelTest {
         verify(repoRepository).unStarLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount)
     }
 
+    @Test
+    fun unStarRepository_unKnownError_updateUiStateToError() = runTest {
+        val repoDetailEntity = makeRepoDetailEntity()
+        whenever(repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name))
+            .thenReturn(Result.failure(CommonException.UnKnownError()))
+
+        detailViewMock.unStarRepository(repoDetailEntity)
+        advanceUntilIdle()
+
+        val uiState = detailViewMock.uiState.value
+        assertTrue(uiState is DetailViewModel.UiState.Error)
+        assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, UNKNOWN)
+        verify(repoRepository).starLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount)
+    }
+
     private fun makeRepoDetailEntity() =
         RepoDetailEntity(
             id = 1,

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -6,6 +6,7 @@ import com.prac.data.exception.CommonException
 import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.constants.CONNECTION_FAIL
+import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.util.FakeBackOffWorkManager
 import com.prac.githubrepo.util.StandardTestDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -96,6 +97,22 @@ class DetailViewModelTest {
         val uiState = detailViewMock.uiState.value
         assertTrue(uiState is DetailViewModel.UiState.Error)
         assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, CONNECTION_FAIL)
+    }
+
+    @Test
+    fun getRepository_authorizationError_updatesUiStateToError() = runTest {
+        val userName = "test"
+        val repoName = "test"
+        whenever(repoRepository.getRepository(userName, repoName))
+            .thenReturn(Result.failure(CommonException.AuthorizationError()))
+
+        detailViewMock.getRepository(userName, repoName)
+        advanceUntilIdle()
+
+        val uiState = detailViewMock.uiState.value
+        assertTrue(uiState is DetailViewModel.UiState.Error)
+        assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, INVALID_TOKEN)
+        verify(tokenRepository).clearToken()
     }
 
     private fun makeRepoDetailEntity() =

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -1,17 +1,25 @@
 package com.prac.githubrepo.main.detail
 
+import com.prac.data.entity.OwnerEntity
+import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.util.FakeBackOffWorkManager
 import com.prac.githubrepo.util.StandardTestDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
@@ -38,4 +46,44 @@ class DetailViewModelTest {
         backOffWork.clearWork()
         backOffWork.clearDelayTimes()
     }
+
+    @Test
+    fun getRepository_validInput_updatesUiStateToContent() = runTest {
+        val userName = "test"
+        val repoName = "test"
+        val repoDetailEntity = makeRepoDetailEntity()
+        val starStateAndCount = Pair(true, 11)
+        whenever(repoRepository.getRepository(userName, repoName))
+            .thenReturn(Result.success(repoDetailEntity))
+        whenever(repoRepository.getStarStateAndStarCount(repoDetailEntity.id))
+            .thenReturn(flow { emit(starStateAndCount) })
+
+        detailViewMock.getRepository(userName, repoName)
+        advanceUntilIdle()
+
+        val uiState = detailViewMock.uiState.value
+        val expectedValue = makeExpectedValue(starStateAndCount.first, starStateAndCount.second)
+        assertTrue(uiState is DetailViewModel.UiState.Content)
+        assertEquals((uiState as DetailViewModel.UiState.Content).repository, expectedValue)
+    }
+
+    private fun makeRepoDetailEntity() =
+        RepoDetailEntity(
+            id = 1,
+            name = "test",
+            owner = OwnerEntity(login = "test", avatarUrl = "test"),
+            stargazersCount = 10,
+            forksCount = 10,
+            isStarred = true
+        )
+
+    private fun makeExpectedValue(isStarred: Boolean, stargazersCount: Int) =
+        RepoDetailEntity(
+            id = 1,
+            name = "test",
+            owner = OwnerEntity(login = "test", avatarUrl = "test"),
+            stargazersCount = stargazersCount,
+            forksCount = 10,
+            isStarred = isStarred
+        )
 }

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -115,6 +115,19 @@ class DetailViewModelTest {
         verify(tokenRepository).clearToken()
     }
 
+    @Test
+    fun starRepository_success_callStarLocalAndRemoteRepository() = runTest {
+        val repoDetailEntity = makeRepoDetailEntity()
+        whenever(repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name))
+            .thenReturn(Result.success(Unit))
+
+        detailViewMock.starRepository(repoDetailEntity)
+        advanceUntilIdle()
+
+        verify(repoRepository).starLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount + 1)
+        verify(repoRepository).starRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
+    }
+
     private fun makeRepoDetailEntity() =
         RepoDetailEntity(
             id = 1,

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -65,6 +66,19 @@ class DetailViewModelTest {
         val expectedValue = makeExpectedValue(starStateAndCount.first, starStateAndCount.second)
         assertTrue(uiState is DetailViewModel.UiState.Content)
         assertEquals((uiState as DetailViewModel.UiState.Content).repository, expectedValue)
+    }
+
+    @Test
+    fun getRepository_invalidInput_updatesUiStateToError() = runTest {
+        val userName = null
+        val repoName = null
+
+        detailViewMock.getRepository(userName, repoName)
+        advanceUntilIdle()
+
+        val uiState = detailViewMock.uiState.value
+        assertTrue(uiState is DetailViewModel.UiState.Error)
+        assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, "잘못된 접근입니다.")
     }
 
     private fun makeRepoDetailEntity() =

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -1,0 +1,41 @@
+package com.prac.githubrepo.main.detail
+
+import com.prac.data.repository.RepoRepository
+import com.prac.data.repository.TokenRepository
+import com.prac.githubrepo.util.FakeBackOffWorkManager
+import com.prac.githubrepo.util.StandardTestDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(MockitoJUnitRunner::class)
+class DetailViewModelTest {
+
+    @get:Rule
+    val standardTestDispatcherRule = StandardTestDispatcherRule()
+
+    @Mock private lateinit var tokenRepository: TokenRepository
+    @Mock private lateinit var repoRepository: RepoRepository
+    private lateinit var backOffWork: FakeBackOffWorkManager
+
+    private lateinit var detailViewMock: DetailViewModel
+
+    @Before
+    fun setUp() = runTest {
+        backOffWork = FakeBackOffWorkManager()
+
+        detailViewMock = DetailViewModel(repoRepository, tokenRepository, backOffWork, standardTestDispatcherRule.testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        backOffWork.clearWork()
+        backOffWork.clearDelayTimes()
+    }
+}

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -128,6 +128,19 @@ class DetailViewModelTest {
         verify(repoRepository).starRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
     }
 
+    @Test
+    fun unStarRepository_success_callStarLocalAndRemoteRepository() = runTest {
+        val repoDetailEntity = makeRepoDetailEntity()
+        whenever(repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name))
+            .thenReturn(Result.success(Unit))
+
+        detailViewMock.unStarRepository(repoDetailEntity)
+        advanceUntilIdle()
+
+        verify(repoRepository).unStarLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount - 1)
+        verify(repoRepository).unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
+    }
+
     private fun makeRepoDetailEntity() =
         RepoDetailEntity(
             id = 1,

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -160,6 +160,24 @@ class DetailViewModelTest {
         assertEquals(backOffWork.getDelayTimes(uniqueID), delayTimes)
     }
 
+    @Test
+    fun unStarRepository_networkError_callMultipleTimesRemoteRepository() = runTest {
+        backOffWork.setScope(this)
+        val repoDetailEntity = makeRepoDetailEntity()
+        val uniqueID = "star_${repoDetailEntity.id}"
+        val callApiTimes = 6 // backOffWorkManager maxTimes(5) + default(1) = 6
+        val delayTimes = 31_000L // 1초 -> 2초 -> 4초 -> 8초 -> 16초 = 31초
+        whenever(repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name))
+            .thenReturn(Result.failure(CommonException.NetworkError()))
+
+        detailViewMock.unStarRepository(repoDetailEntity)
+        advanceUntilIdle()
+
+        verify(repoRepository).unStarLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount - 1)
+        verify(repoRepository, times(callApiTimes)).unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
+        assertEquals(backOffWork.getDelayTimes(uniqueID), delayTimes)
+    }
+
     private fun makeRepoDetailEntity() =
         RepoDetailEntity(
             id = 1,

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -178,6 +178,21 @@ class DetailViewModelTest {
         assertEquals(backOffWork.getDelayTimes(uniqueID), delayTimes)
     }
 
+    @Test
+    fun starRepository_authorizationError_updateUiStateToError() = runTest {
+        val repoDetailEntity = makeRepoDetailEntity()
+        whenever(repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name))
+            .thenReturn(Result.failure(CommonException.AuthorizationError()))
+
+        detailViewMock.starRepository(repoDetailEntity)
+        advanceUntilIdle()
+
+        val uiState = detailViewMock.uiState.value
+        assertTrue(uiState is DetailViewModel.UiState.Error)
+        assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, INVALID_TOKEN)
+        verify(tokenRepository).clearToken()
+    }
+
     private fun makeRepoDetailEntity() =
         RepoDetailEntity(
             id = 1,

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -193,6 +193,21 @@ class DetailViewModelTest {
         verify(tokenRepository).clearToken()
     }
 
+    @Test
+    fun unStarRepository_authorizationError_updateUiStateDialogMessage() = runTest {
+        val repoDetailEntity = makeRepoDetailEntity()
+        whenever(repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name))
+            .thenReturn(Result.failure(CommonException.AuthorizationError()))
+
+        detailViewMock.unStarRepository(repoDetailEntity)
+        advanceUntilIdle()
+
+        val uiState = detailViewMock.uiState.value
+        assertTrue(uiState is DetailViewModel.UiState.Error)
+        assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, INVALID_TOKEN)
+        verify(tokenRepository).clearToken()
+    }
+
     private fun makeRepoDetailEntity() =
         RepoDetailEntity(
             id = 1,

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -2,8 +2,10 @@ package com.prac.githubrepo.main.detail
 
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoDetailEntity
+import com.prac.data.exception.CommonException
 import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
+import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.util.FakeBackOffWorkManager
 import com.prac.githubrepo.util.StandardTestDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -79,6 +81,21 @@ class DetailViewModelTest {
         val uiState = detailViewMock.uiState.value
         assertTrue(uiState is DetailViewModel.UiState.Error)
         assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, "잘못된 접근입니다.")
+    }
+
+    @Test
+    fun getRepository_networkError_updatesUiStateToError() = runTest {
+        val userName = "test"
+        val repoName = "test"
+        whenever(repoRepository.getRepository(userName, repoName))
+            .thenReturn(Result.failure(CommonException.NetworkError()))
+
+        detailViewMock.getRepository(userName, repoName)
+        advanceUntilIdle()
+
+        val uiState = detailViewMock.uiState.value
+        assertTrue(uiState is DetailViewModel.UiState.Error)
+        assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, CONNECTION_FAIL)
     }
 
     private fun makeRepoDetailEntity() =

--- a/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/detail/DetailViewModelTest.kt
@@ -225,6 +225,21 @@ class DetailViewModelTest {
         verify(repoRepository).unStarLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount)
     }
 
+    @Test
+    fun unStarRepository_repositoryIsNotFoundError_updateUiStateToError() = runTest {
+        val repoDetailEntity = makeRepoDetailEntity()
+        whenever(repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name))
+            .thenReturn(Result.failure(RepositoryException.NotFoundRepository()))
+
+        detailViewMock.unStarRepository(repoDetailEntity)
+        advanceUntilIdle()
+
+        val uiState = detailViewMock.uiState.value
+        assertTrue(uiState is DetailViewModel.UiState.Error)
+        assertEquals((uiState as DetailViewModel.UiState.Error).errorMessage, INVALID_REPOSITORY)
+        verify(repoRepository).starLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount)
+    }
+
     private fun makeRepoDetailEntity() =
         RepoDetailEntity(
             id = 1,

--- a/app/src/test/java/com/prac/githubrepo/util/BackOffWorkManagerTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/util/BackOffWorkManagerTest.kt
@@ -1,5 +1,6 @@
 package com.prac.githubrepo.util
 
+import com.prac.data.exception.CommonException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -15,15 +16,82 @@ import java.io.IOException
 
 class BackOffWorkManagerTest {
 
-    private lateinit var backOffWorkManager: BackOffWorkManager
+    private lateinit var backOffWorkManager: FakeBackOffWorkManager
 
     @Before
     fun setUp() {
-
+        backOffWorkManager = FakeBackOffWorkManager()
     }
 
     @After
     fun tearDown() {
+        backOffWorkManager.clearWork()
+        backOffWorkManager.clearDelayTimes()
+    }
 
+    class FakeBackOffWorkManager : BackOffWorkManager {
+        private val _workMap = mutableMapOf<String, Job>()
+        private val _delayTimesMap = mutableMapOf<String, Long>()
+
+        private lateinit var scope: CoroutineScope
+
+        override fun addWork(
+            uniqueID: String,
+            times: Int,
+            initialDelay: Long,
+            maxDelay: Long,
+            factor: Double,
+            work: suspend () -> Result<*>
+        ) {
+            if (!::scope.isInitialized) {
+                throw Exception("scope not initialized")
+            }
+
+            removeWork(uniqueID)
+            _delayTimesMap.remove(uniqueID)
+
+            var currentDelay = initialDelay
+
+            val job = scope.launch {
+                repeat(times) {
+                    work()
+                        .onSuccess {
+                            removeWork(uniqueID)
+                            return@launch
+                        }
+                        .onFailure {
+                            if (it !is CommonException.NetworkError) {
+                                removeWork(uniqueID)
+                                return@launch
+                            }
+                        }
+                    _delayTimesMap[uniqueID] = (_delayTimesMap[uniqueID] ?: 0L) + currentDelay
+                    currentDelay = (currentDelay * factor).toLong().coerceAtMost(maxDelay)
+                }
+                removeWork(uniqueID)
+            }
+
+            _workMap[uniqueID] = job
+        }
+
+        override fun clearWork() {
+            _workMap.clear()
+        }
+
+        fun setScope(scope: CoroutineScope) {
+            this.scope = scope
+        }
+
+        fun clearDelayTimes() {
+            _delayTimesMap.clear()
+        }
+
+        fun getDelayTimes(uniqueID: String) : Long =
+            _delayTimesMap[uniqueID] ?: 0L
+
+        private fun removeWork(uniqueID: String) {
+            _workMap[uniqueID]?.cancel()
+            _workMap.remove(uniqueID)
+        }
     }
 }

--- a/app/src/test/java/com/prac/githubrepo/util/BackOffWorkManagerTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/util/BackOffWorkManagerTest.kt
@@ -1,10 +1,7 @@
 package com.prac.githubrepo.util
 
 import com.prac.data.exception.CommonException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -116,71 +113,5 @@ class BackOffWorkManagerTest {
         advanceUntilIdle()
         assertEquals(retryTimes, maxRetryTimes)
         assertEquals(backOffWorkManager.getDelayTimes(uniqueID), delayTimes)
-    }
-
-    class FakeBackOffWorkManager : BackOffWorkManager {
-        private val _workMap = mutableMapOf<String, Job>()
-        private val _delayTimesMap = mutableMapOf<String, Long>()
-
-        private lateinit var scope: CoroutineScope
-
-        override fun addWork(
-            uniqueID: String,
-            times: Int,
-            initialDelay: Long,
-            maxDelay: Long,
-            factor: Double,
-            work: suspend () -> Result<*>
-        ) {
-            if (!::scope.isInitialized) {
-                throw Exception("scope not initialized")
-            }
-
-            removeWork(uniqueID)
-            _delayTimesMap.remove(uniqueID)
-
-            var currentDelay = initialDelay
-
-            val job = scope.launch {
-                repeat(times) {
-                    work()
-                        .onSuccess {
-                            removeWork(uniqueID)
-                            return@launch
-                        }
-                        .onFailure {
-                            if (it !is CommonException.NetworkError) {
-                                removeWork(uniqueID)
-                                return@launch
-                            }
-                        }
-                    _delayTimesMap[uniqueID] = (_delayTimesMap[uniqueID] ?: 0L) + currentDelay
-                    currentDelay = (currentDelay * factor).toLong().coerceAtMost(maxDelay)
-                }
-                removeWork(uniqueID)
-            }
-
-            _workMap[uniqueID] = job
-        }
-
-        override fun clearWork() {
-            _workMap.clear()
-        }
-
-        fun setScope(scope: CoroutineScope) {
-            this.scope = scope
-        }
-
-        fun clearDelayTimes() {
-            _delayTimesMap.clear()
-        }
-
-        fun getDelayTimes(uniqueID: String) : Long =
-            _delayTimesMap[uniqueID] ?: 0L
-
-        private fun removeWork(uniqueID: String) {
-            _workMap[uniqueID]?.cancel()
-            _workMap.remove(uniqueID)
-        }
     }
 }

--- a/app/src/test/java/com/prac/githubrepo/util/BackOffWorkManagerTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/util/BackOffWorkManagerTest.kt
@@ -1,0 +1,29 @@
+package com.prac.githubrepo.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class BackOffWorkManagerTest {
+
+    private lateinit var backOffWorkManager: BackOffWorkManager
+
+    @Before
+    fun setUp() {
+
+    }
+
+    @After
+    fun tearDown() {
+
+    }
+}

--- a/app/src/test/java/com/prac/githubrepo/util/FakeBackOffWorkManager.kt
+++ b/app/src/test/java/com/prac/githubrepo/util/FakeBackOffWorkManager.kt
@@ -1,0 +1,73 @@
+package com.prac.githubrepo.util
+
+import com.prac.data.exception.CommonException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.io.IOException
+
+class FakeBackOffWorkManager : BackOffWorkManager {
+    private val _workMap = mutableMapOf<String, Job>()
+    private val _delayTimesMap = mutableMapOf<String, Long>()
+
+    private lateinit var scope: CoroutineScope
+
+    override fun addWork(
+        uniqueID: String,
+        times: Int,
+        initialDelay: Long,
+        maxDelay: Long,
+        factor: Double,
+        work: suspend () -> Result<*>
+    ) {
+        if (!::scope.isInitialized) {
+            throw Exception("scope not initialized")
+        }
+
+        removeWork(uniqueID)
+        _delayTimesMap.remove(uniqueID)
+
+        var currentDelay = initialDelay
+
+        val job = scope.launch {
+            repeat(times) {
+                work()
+                    .onSuccess {
+                        removeWork(uniqueID)
+                        return@launch
+                    }
+                    .onFailure {
+                        if (it !is CommonException.NetworkError) {
+                            removeWork(uniqueID)
+                            return@launch
+                        }
+                    }
+                _delayTimesMap[uniqueID] = (_delayTimesMap[uniqueID] ?: 0L) + currentDelay
+                currentDelay = (currentDelay * factor).toLong().coerceAtMost(maxDelay)
+            }
+            removeWork(uniqueID)
+        }
+
+        _workMap[uniqueID] = job
+    }
+
+    override fun clearWork() {
+        _workMap.clear()
+    }
+
+    fun setScope(scope: CoroutineScope) {
+        this.scope = scope
+    }
+
+    fun clearDelayTimes() {
+        _delayTimesMap.clear()
+    }
+
+    fun getDelayTimes(uniqueID: String) : Long =
+        _delayTimesMap[uniqueID] ?: 0L
+
+    private fun removeWork(uniqueID: String) {
+        _workMap[uniqueID]?.cancel()
+        _workMap.remove(uniqueID)
+    }
+}

--- a/app/src/test/java/com/prac/githubrepo/util/FakeBackOffWorkManager.kt
+++ b/app/src/test/java/com/prac/githubrepo/util/FakeBackOffWorkManager.kt
@@ -26,11 +26,12 @@ class FakeBackOffWorkManager : BackOffWorkManager {
 
         removeWork(uniqueID)
         _delayTimesMap.remove(uniqueID)
+        val maxTimes = times.coerceAtMost(5)
 
         var currentDelay = initialDelay
 
         val job = scope.launch {
-            repeat(times) {
+            repeat(maxTimes) {
                 work()
                     .onSuccess {
                         removeWork(uniqueID)

--- a/app/src/test/java/com/prac/githubrepo/util/StandardTestDispatcherRule.kt
+++ b/app/src/test/java/com/prac/githubrepo/util/StandardTestDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.prac.githubrepo.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StandardTestDispatcherRule(
+    val testDispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/prac/githubrepo/util/UnconfinedTestDispatcherRule.kt
+++ b/app/src/test/java/com/prac/githubrepo/util/UnconfinedTestDispatcherRule.kt
@@ -1,0 +1,23 @@
+package com.prac.githubrepo.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UnconfinedTestDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/data/src/main/java/com/prac/data/exception/AuthException.kt
+++ b/data/src/main/java/com/prac/data/exception/AuthException.kt
@@ -1,9 +1,0 @@
-package com.prac.data.exception
-
-sealed class AuthException : Exception() {
-    class NetworkError : AuthException()
-
-    class AuthorizationError : AuthException()
-
-    class UnKnownError : AuthException()
-}

--- a/data/src/main/java/com/prac/data/exception/CommonException.kt
+++ b/data/src/main/java/com/prac/data/exception/CommonException.kt
@@ -1,0 +1,9 @@
+package com.prac.data.exception
+
+sealed class CommonException : Exception(){
+    class NetworkError : CommonException()
+
+    class AuthorizationError : CommonException()
+
+    class UnKnownError : CommonException()
+}

--- a/data/src/main/java/com/prac/data/exception/RepositoryException.kt
+++ b/data/src/main/java/com/prac/data/exception/RepositoryException.kt
@@ -1,11 +1,5 @@
 package com.prac.data.exception
 
 sealed class RepositoryException :Exception() {
-    class NetworkError : RepositoryException()
-
-    class AuthorizationError : RepositoryException()
-
     class NotFoundRepository : RepositoryException()
-
-    class UnKnownError : RepositoryException()
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -11,7 +11,7 @@ import androidx.room.withTransaction
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.entity.RepoEntity
-import com.prac.data.exception.AuthException
+import com.prac.data.exception.CommonException
 import com.prac.data.exception.RepositoryException
 import com.prac.data.repository.RepoRepository
 import com.prac.data.source.local.room.database.RepositoryDatabase
@@ -180,13 +180,13 @@ internal class RepoRepositoryImpl @Inject constructor(
         return when (e) {
             is HttpException -> {
                 when (e.code()) {
-                    401 -> Result.failure(RepositoryException.AuthorizationError())
+                    401 -> Result.failure(CommonException.AuthorizationError())
                     404 -> Result.failure(RepositoryException.NotFoundRepository())
-                    else -> Result.failure(AuthException.UnKnownError())
+                    else -> Result.failure(CommonException.UnKnownError())
                 }
             }
-            is IOException -> Result.failure(RepositoryException.NetworkError())
-            else -> Result.failure(AuthException.UnKnownError())
+            is IOException -> Result.failure(CommonException.NetworkError())
+            else -> Result.failure(CommonException.UnKnownError())
         }
     }
 

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -1,11 +1,11 @@
 package com.prac.data.repository.impl
 
-import com.prac.data.exception.AuthException
+import com.prac.data.exception.CommonException
 import com.prac.data.repository.TokenRepository
 import com.prac.data.repository.model.TokenModel
-import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.local.datastore.TokenLocalDto
+import com.prac.data.source.network.AuthApiDataSource
 import retrofit2.HttpException
 import java.io.IOException
 import javax.inject.Inject
@@ -21,14 +21,14 @@ internal class TokenRepositoryImpl @Inject constructor(
 
             Result.success(Unit)
         } catch (e: HttpException) {
-            Result.failure(AuthException.AuthorizationError())
+            Result.failure(CommonException.AuthorizationError())
         } catch (e: Exception) {
             when (e) {
                 is IOException -> {
-                    Result.failure(AuthException.NetworkError())
+                    Result.failure(CommonException.NetworkError())
                 }
                 else -> {
-                    Result.failure(AuthException.UnKnownError())
+                    Result.failure(CommonException.UnKnownError())
                 }
             }
         }


### PR DESCRIPTION
notion - https://www.notion.so/refact-exception-sealed-class-11fa26591b61809480e5c630d4151de8?pvs=4

# AS-IS

- 현재 BackoffManager 에 등록된 작업에서 IOException 이 아닌 예외가 발생할 경우 작업을 취소하도록 구현되어 있지만AuthException.NetworkError, RepositoryException.NetworkError 로 따로 받고 있기 때문에  BackOff 가 제대로 동작하지 않음

# TO-BE

```jsx
sealed class CommonException : Exception(){
    class NetworkError : CommonException()

    class AuthorizationError : CommonException()

    class UnKnownError : CommonException()
}

sealed class RepositoryException :Exception() {
    class NotFoundRepository : RepositoryException()
}
```

- AuthException 및 RepositoryException 에서 공통으로 사용되는 class 를 위한 CommonException sealed class 생성
- AuthException sealed class 제거 및 Repository sealed class 변경