### PR TITLE
feat: User 정보를 가져오는 Api, User 정보를 저장하는 DataStore 생성

### DIFF
--- a/data/src/androidTest/java/com/prac/data/repository/RepoRepositoryTest.kt
+++ b/data/src/androidTest/java/com/prac/data/repository/RepoRepositoryTest.kt
@@ -11,9 +11,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.prac.data.exception.CommonException
 import com.prac.data.exception.RepositoryException
+import com.prac.data.fake.source.local.FakeUserLocalDataSource
 import com.prac.data.fake.source.network.FakeRepoApiDataSource
 import com.prac.data.fake.source.network.FakeRepoStarApiDataSource
 import com.prac.data.repository.impl.RepoRepositoryImpl
+import com.prac.data.source.local.UserLocalDataSource
 import com.prac.data.source.local.room.dao.RemoteKeyDao
 import com.prac.data.source.local.room.dao.RepositoryDao
 import com.prac.data.source.local.room.database.RepositoryDatabase
@@ -22,10 +24,10 @@ import com.prac.data.source.local.room.entity.Repository
 import com.prac.data.source.network.dto.OwnerDto
 import com.prac.data.source.network.dto.RepoDto
 import kotlinx.coroutines.flow.first
-import org.junit.Assert.assertEquals
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -40,6 +42,7 @@ internal class RepoRepositoryTest {
 
     private lateinit var repoApiDataSource: FakeRepoApiDataSource
     private lateinit var repoStarApiDataSource: FakeRepoStarApiDataSource
+    private lateinit var userLocalDataSource: UserLocalDataSource
 
     private lateinit var repositoryDatabase: RepositoryDatabase
     private lateinit var remoteKeyDao: RemoteKeyDao
@@ -55,6 +58,7 @@ internal class RepoRepositoryTest {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         repoApiDataSource = FakeRepoApiDataSource()
         repoStarApiDataSource = FakeRepoStarApiDataSource()
+        userLocalDataSource = FakeUserLocalDataSource()
 
         repositoryDatabase = Room
             .inMemoryDatabaseBuilder(context, RepositoryDatabase::class.java)
@@ -63,7 +67,7 @@ internal class RepoRepositoryTest {
         remoteKeyDao = repositoryDatabase.remoteKeyDao()
         repositoryDao = repositoryDatabase.repositoryDao()
 
-        repoRepository = RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource, repositoryDatabase)
+        repoRepository = RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource, repositoryDatabase, userLocalDataSource)
     }
 
     @After

--- a/data/src/main/java/com/prac/data/fake/repository/FakeTokenRepository.kt
+++ b/data/src/main/java/com/prac/data/fake/repository/FakeTokenRepository.kt
@@ -2,7 +2,7 @@ package com.prac.data.fake.repository
 
 import com.prac.data.exception.CommonException
 import com.prac.data.repository.TokenRepository
-import com.prac.data.source.local.datastore.TokenLocalDto
+import com.prac.data.source.local.datastore.token.TokenLocalDto
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime

--- a/data/src/main/java/com/prac/data/fake/source/local/FakeTokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/fake/source/local/FakeTokenDataStoreManager.kt
@@ -1,7 +1,7 @@
 package com.prac.data.fake.source.local
 
-import com.prac.data.source.local.datastore.TokenDataStoreManager
-import com.prac.data.source.local.datastore.TokenLocalDto
+import com.prac.data.source.local.datastore.token.TokenDataStoreManager
+import com.prac.data.source.local.datastore.token.TokenLocalDto
 import java.time.Instant
 import java.time.ZoneId
 

--- a/data/src/main/java/com/prac/data/fake/source/local/FakeTokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/fake/source/local/FakeTokenLocalDataSource.kt
@@ -1,7 +1,7 @@
 package com.prac.data.fake.source.local
 
 import com.prac.data.source.local.TokenLocalDataSource
-import com.prac.data.source.local.datastore.TokenLocalDto
+import com.prac.data.source.local.datastore.token.TokenLocalDto
 import java.time.Instant
 import java.time.ZoneId
 

--- a/data/src/main/java/com/prac/data/fake/source/local/FakeUserDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/fake/source/local/FakeUserDataStoreManager.kt
@@ -1,0 +1,20 @@
+package com.prac.data.fake.source.local
+
+import com.prac.data.source.local.datastore.user.UserDataStoreManager
+
+internal class FakeUserDataStoreManager : UserDataStoreManager {
+
+    private var userName = ""
+
+    override suspend fun setUserName(userName: String) {
+        this.userName = userName
+    }
+
+    override suspend fun getUserName(): String {
+        return userName
+    }
+
+    override suspend fun clearUserName() {
+        this.userName = ""
+    }
+}

--- a/data/src/main/java/com/prac/data/fake/source/local/FakeUserLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/fake/source/local/FakeUserLocalDataSource.kt
@@ -1,0 +1,20 @@
+package com.prac.data.fake.source.local
+
+import com.prac.data.source.local.UserLocalDataSource
+
+internal class FakeUserLocalDataSource : UserLocalDataSource {
+
+    private var userName = ""
+
+    override suspend fun setUserName(userName: String) {
+        this.userName = userName
+    }
+
+    override suspend fun getUserName(): String {
+        return userName
+    }
+
+    override suspend fun clearUserName() {
+        this.userName = ""
+    }
+}

--- a/data/src/main/java/com/prac/data/fake/source/network/FakeRepoStarApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/fake/source/network/FakeRepoStarApiDataSource.kt
@@ -10,7 +10,7 @@ class FakeRepoStarApiDataSource: RepoStarApiDataSource {
         this.throwable = throwable
     }
 
-    override suspend fun checkRepositoryIsStarred(repoName: String) {
+    override suspend fun isStarred(userName: String, repoName: String) {
         if (::throwable.isInitialized) {
             throw throwable
         }

--- a/data/src/main/java/com/prac/data/fake/source/network/FakeUserApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/fake/source/network/FakeUserApiDataSource.kt
@@ -1,0 +1,9 @@
+package com.prac.data.fake.source.network
+
+import com.prac.data.source.network.UserApiDataSource
+
+class FakeUserApiDataSource : UserApiDataSource {
+    override suspend fun getUserName(accessToken: String): String {
+        return "test"
+    }
+}

--- a/data/src/main/java/com/prac/data/fake/source/network/service/FakeGitHubService.kt
+++ b/data/src/main/java/com/prac/data/fake/source/network/service/FakeGitHubService.kt
@@ -29,7 +29,7 @@ internal class FakeGitHubService(
         )
     }
 
-    override suspend fun checkRepositoryIsStarred(userName: String, repoName: String) {
+    override suspend fun isStarred(userName: String, repoName: String) {
         throw NotImplementedError("this method is not supported in FakeGitHubService")
     }
 

--- a/data/src/main/java/com/prac/data/fake/source/network/service/FakeGitHubUserService.kt
+++ b/data/src/main/java/com/prac/data/fake/source/network/service/FakeGitHubUserService.kt
@@ -1,0 +1,17 @@
+package com.prac.data.fake.source.network.service
+
+import com.prac.data.source.network.dto.AccessTokenRequest
+import com.prac.data.source.network.dto.OwnerDto
+import com.prac.data.source.network.dto.UserDto
+import com.prac.data.source.network.service.GitHubUserService
+
+internal class FakeGitHubUserService : GitHubUserService {
+    override suspend fun getUserInformation(clientId: String, accept: String, authorization: String, accessToken: AccessTokenRequest): UserDto {
+        return UserDto(
+            user = OwnerDto(
+                login = "test",
+                avatarUrl = "test"
+            )
+        )
+    }
+}

--- a/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
+++ b/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
@@ -9,6 +9,7 @@ import com.prac.data.source.network.RepoStarApiDataSource
 import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.local.room.database.RepositoryDatabase
+import com.prac.data.source.network.UserApiDataSource
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -22,9 +23,10 @@ internal class RepositoryModule {
     @Singleton
     fun provideTokenRepository(
         tokenLocalDataSource: TokenLocalDataSource,
-        authApiDataSource: AuthApiDataSource
+        authApiDataSource: AuthApiDataSource,
+        userApiDataSource: UserApiDataSource
     ): TokenRepository =
-        TokenRepositoryImpl(tokenLocalDataSource, authApiDataSource)
+        TokenRepositoryImpl(tokenLocalDataSource, authApiDataSource, userApiDataSource)
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
+++ b/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
@@ -4,11 +4,12 @@ import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
 import com.prac.data.repository.impl.RepoRepositoryImpl
 import com.prac.data.repository.impl.TokenRepositoryImpl
+import com.prac.data.source.local.TokenLocalDataSource
+import com.prac.data.source.local.UserLocalDataSource
+import com.prac.data.source.local.room.database.RepositoryDatabase
+import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
-import com.prac.data.source.network.AuthApiDataSource
-import com.prac.data.source.local.TokenLocalDataSource
-import com.prac.data.source.local.room.database.RepositoryDatabase
 import com.prac.data.source.network.UserApiDataSource
 import dagger.Module
 import dagger.Provides
@@ -24,9 +25,10 @@ internal class RepositoryModule {
     fun provideTokenRepository(
         tokenLocalDataSource: TokenLocalDataSource,
         authApiDataSource: AuthApiDataSource,
-        userApiDataSource: UserApiDataSource
+        userApiDataSource: UserApiDataSource,
+        userLocalDataSource: UserLocalDataSource
     ): TokenRepository =
-        TokenRepositoryImpl(tokenLocalDataSource, authApiDataSource, userApiDataSource)
+        TokenRepositoryImpl(tokenLocalDataSource, authApiDataSource, userApiDataSource, userLocalDataSource)
 
     @Provides
     @Singleton

--- a/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
+++ b/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
@@ -35,7 +35,8 @@ internal class RepositoryModule {
     fun provideRepoRepository(
         repoApiDataSource: RepoApiDataSource,
         repoStarApiDataSource: RepoStarApiDataSource,
-        repositoryDatabase: RepositoryDatabase
+        repositoryDatabase: RepositoryDatabase,
+        userLocalDataSource: UserLocalDataSource
     ): RepoRepository =
-        RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource, repositoryDatabase)
+        RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource, repositoryDatabase, userLocalDataSource)
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -74,7 +74,9 @@ internal class RepoRepositoryImpl @Inject constructor(
 
     override suspend fun isStarred(id: Int, repoName: String) {
         try {
-            repoStarApiDataSource.checkRepositoryIsStarred(repoName)
+            val userName = userLocalDataSource.getUserName()
+
+            repoStarApiDataSource.isStarred(userName, repoName)
 
             repositoryDatabase.repositoryDao().updateStarState(id, true)
         } catch (e: Exception) {

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.prac.data.entity.RepoEntity
 import com.prac.data.exception.CommonException
 import com.prac.data.exception.RepositoryException
 import com.prac.data.repository.RepoRepository
+import com.prac.data.source.local.UserLocalDataSource
 import com.prac.data.source.local.room.database.RepositoryDatabase
 import com.prac.data.source.local.room.entity.Owner
 import com.prac.data.source.local.room.entity.RemoteKey
@@ -29,7 +30,8 @@ import javax.inject.Inject
 internal class RepoRepositoryImpl @Inject constructor(
     private val repoApiDataSource: RepoApiDataSource,
     private val repoStarApiDataSource: RepoStarApiDataSource,
-    private val repositoryDatabase: RepositoryDatabase
+    private val repositoryDatabase: RepositoryDatabase,
+    private val userLocalDataSource: UserLocalDataSource
 ) : RepoRepository() {
 
     @OptIn(ExperimentalPagingApi::class)
@@ -130,7 +132,8 @@ internal class RepoRepositoryImpl @Inject constructor(
         }
 
         try {
-            val response = repoApiDataSource.getRepositories("GongDoMin", PAGE_SIZE, page)
+            val userName = userLocalDataSource.getUserName()
+            val response = repoApiDataSource.getRepositories(userName, PAGE_SIZE, page)
 
             repositoryDatabase.withTransaction {
                 if (loadType == LoadType.REFRESH) {

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -4,7 +4,7 @@ import com.prac.data.exception.CommonException
 import com.prac.data.repository.TokenRepository
 import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.local.TokenLocalDataSource
-import com.prac.data.source.local.datastore.TokenLocalDto
+import com.prac.data.source.local.datastore.token.TokenLocalDto
 import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.network.UserApiDataSource
 import java.io.IOException

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.prac.data.exception.CommonException
 import com.prac.data.repository.TokenRepository
 import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.local.TokenLocalDataSource
+import com.prac.data.source.local.UserLocalDataSource
 import com.prac.data.source.local.datastore.token.TokenLocalDto
 import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.network.UserApiDataSource
@@ -13,14 +14,16 @@ import javax.inject.Inject
 internal class TokenRepositoryImpl @Inject constructor(
     private val tokenLocalDataSource: TokenLocalDataSource,
     private val authApiDataSource: AuthApiDataSource,
-    private val userApiDataSource: UserApiDataSource
+    private val userApiDataSource: UserApiDataSource,
+    private val userLocalDataSource: UserLocalDataSource
 ) : TokenRepository {
     override suspend fun authorizeOAuth(code: String): Result<Unit> {
         return try {
             val model = authApiDataSource.authorizeOAuth(code)
-            getUserName(model.accessToken)
+            val userName = getUserName(model.accessToken)
 
             setToken(model)
+            setUserName(userName)
 
             Result.success(Unit)
         } catch (e: Exception) {
@@ -88,5 +91,9 @@ internal class TokenRepositoryImpl @Inject constructor(
         // 422 : Client id or Client secret is invalid
         // authorizeOAuth 에서 에러 처리
         return userApiDataSource.getUserName(accessToken)
+    }
+
+    private suspend fun setUserName(userName: String) {
+        userLocalDataSource.setUserName(userName)
     }
 }

--- a/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/local/TokenLocalDataSource.kt
@@ -1,6 +1,6 @@
 package com.prac.data.source.local
 
-import com.prac.data.source.local.datastore.TokenLocalDto
+import com.prac.data.source.local.datastore.token.TokenLocalDto
 
 internal interface TokenLocalDataSource {
     suspend fun setToken(token: TokenLocalDto)

--- a/data/src/main/java/com/prac/data/source/local/UserLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/local/UserLocalDataSource.kt
@@ -1,0 +1,9 @@
+package com.prac.data.source.local
+
+internal interface UserLocalDataSource {
+    suspend fun setUserName(userName: String)
+
+    suspend fun getUserName() : String
+
+    suspend fun clearUserName()
+}

--- a/data/src/main/java/com/prac/data/source/local/datastore/UserDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/UserDataStoreManager.kt
@@ -1,0 +1,9 @@
+package com.prac.data.source.local.datastore
+
+internal interface UserDataStoreManager {
+    suspend fun setUserName(userName: String)
+
+    suspend fun getUserName(): String
+
+    suspend fun clearUserName()
+}

--- a/data/src/main/java/com/prac/data/source/local/datastore/UserDataStoreManagerImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/UserDataStoreManagerImpl.kt
@@ -1,0 +1,59 @@
+package com.prac.data.source.local.datastore
+
+import android.content.Context
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import com.google.protobuf.InvalidProtocolBufferException
+import com.prac.data.datastore.User
+import kotlinx.coroutines.flow.first
+import java.io.InputStream
+import java.io.OutputStream
+
+internal class UserDataStoreManagerImpl(
+    private val mContext: Context
+) : UserDataStoreManager {
+
+    companion object {
+        private const val USER_DATA_STORE_NAME = "userDataStore"
+    }
+
+    private class TokenSerializer : Serializer<User> {
+        override val defaultValue: User = User.getDefaultInstance()
+        override suspend fun readFrom(input: InputStream): User {
+            try {
+                return User.parseFrom(input)
+            } catch (exception: InvalidProtocolBufferException) {
+                throw CorruptionException("Cannot read proto.", exception)
+            }
+        }
+
+        override suspend fun writeTo(t: User, output: OutputStream) = t.writeTo(output)
+    }
+
+    private val Context.userDataStore: DataStore<User> by dataStore(
+        fileName = USER_DATA_STORE_NAME,
+        serializer = TokenSerializer(),
+    )
+
+    override suspend fun setUserName(userName: String) {
+        mContext.userDataStore.updateData {
+            it.toBuilder()
+                .setUserName(userName)
+                .build()
+        }
+    }
+
+    override suspend fun getUserName(): String {
+        return mContext.userDataStore.data.first().userName
+    }
+
+    override suspend fun clearUserName() {
+        mContext.userDataStore.updateData {
+            it.toBuilder()
+                .clear()
+                .build()
+        }
+    }
+}

--- a/data/src/main/java/com/prac/data/source/local/datastore/token/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/token/TokenDataStoreManager.kt
@@ -1,4 +1,4 @@
-package com.prac.data.source.local.datastore
+package com.prac.data.source.local.datastore.token
 
 internal interface TokenDataStoreManager {
     suspend fun saveTokenData(token: TokenLocalDto)

--- a/data/src/main/java/com/prac/data/source/local/datastore/token/TokenDataStoreManagerImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/token/TokenDataStoreManagerImpl.kt
@@ -1,4 +1,4 @@
-package com.prac.data.source.local.datastore
+package com.prac.data.source.local.datastore.token
 
 import android.content.Context
 import androidx.datastore.core.CorruptionException

--- a/data/src/main/java/com/prac/data/source/local/datastore/token/TokenLocalDto.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/token/TokenLocalDto.kt
@@ -1,4 +1,4 @@
-package com.prac.data.source.local.datastore
+package com.prac.data.source.local.datastore.token
 
 import java.time.ZonedDateTime
 

--- a/data/src/main/java/com/prac/data/source/local/datastore/user/UserDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/user/UserDataStoreManager.kt
@@ -1,4 +1,4 @@
-package com.prac.data.source.local.datastore
+package com.prac.data.source.local.datastore.user
 
 internal interface UserDataStoreManager {
     suspend fun setUserName(userName: String)

--- a/data/src/main/java/com/prac/data/source/local/datastore/user/UserDataStoreManagerImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/datastore/user/UserDataStoreManagerImpl.kt
@@ -1,4 +1,4 @@
-package com.prac.data.source.local.datastore
+package com.prac.data.source.local.datastore.user
 
 import android.content.Context
 import androidx.datastore.core.CorruptionException

--- a/data/src/main/java/com/prac/data/source/local/di/DataStoreModule.kt
+++ b/data/src/main/java/com/prac/data/source/local/di/DataStoreModule.kt
@@ -1,10 +1,10 @@
 package com.prac.data.source.local.di
 
 import android.content.Context
-import com.prac.data.source.local.datastore.TokenDataStoreManager
-import com.prac.data.source.local.datastore.TokenDataStoreManagerImpl
-import com.prac.data.source.local.datastore.UserDataStoreManager
-import com.prac.data.source.local.datastore.UserDataStoreManagerImpl
+import com.prac.data.source.local.datastore.token.TokenDataStoreManager
+import com.prac.data.source.local.datastore.token.TokenDataStoreManagerImpl
+import com.prac.data.source.local.datastore.user.UserDataStoreManager
+import com.prac.data.source.local.datastore.user.UserDataStoreManagerImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/data/src/main/java/com/prac/data/source/local/di/DataStoreModule.kt
+++ b/data/src/main/java/com/prac/data/source/local/di/DataStoreModule.kt
@@ -3,6 +3,8 @@ package com.prac.data.source.local.di
 import android.content.Context
 import com.prac.data.source.local.datastore.TokenDataStoreManager
 import com.prac.data.source.local.datastore.TokenDataStoreManagerImpl
+import com.prac.data.source.local.datastore.UserDataStoreManager
+import com.prac.data.source.local.datastore.UserDataStoreManagerImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -12,10 +14,16 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-internal class TokenDataStoreModule {
+internal class DataStoreModule {
     @Provides
     @Singleton
     fun provideTokenDataStoreManager(@ApplicationContext context: Context) : TokenDataStoreManager {
         return TokenDataStoreManagerImpl(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideUserDataStoreManager(@ApplicationContext context: Context) : UserDataStoreManager {
+        return UserDataStoreManagerImpl(context)
     }
 }

--- a/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/TokenLocalDataSourceImpl.kt
@@ -1,9 +1,8 @@
 package com.prac.data.source.local.impl
 
-import com.prac.data.source.local.datastore.TokenDataStoreManagerImpl
 import com.prac.data.source.local.TokenLocalDataSource
-import com.prac.data.source.local.datastore.TokenDataStoreManager
-import com.prac.data.source.local.datastore.TokenLocalDto
+import com.prac.data.source.local.datastore.token.TokenDataStoreManager
+import com.prac.data.source.local.datastore.token.TokenLocalDto
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject

--- a/data/src/main/java/com/prac/data/source/local/impl/UserLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/UserLocalDataSourceImpl.kt
@@ -2,20 +2,32 @@ package com.prac.data.source.local.impl
 
 import com.prac.data.source.local.UserLocalDataSource
 import com.prac.data.source.local.datastore.user.UserDataStoreManager
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 internal class UserLocalDataSourceImpl @Inject constructor(
     private val userDataStoreManager: UserDataStoreManager
 ) : UserLocalDataSource {
+
+    private var cachedUserName = ""
+
+    init {
+        runBlocking {
+            cachedUserName = userDataStoreManager.getUserName()
+        }
+    }
+
     override suspend fun setUserName(userName: String) {
         userDataStoreManager.setUserName(userName)
+        cachedUserName = userName
     }
 
     override suspend fun getUserName(): String {
-        return userDataStoreManager.getUserName()
+        return cachedUserName
     }
 
     override suspend fun clearUserName() {
         userDataStoreManager.clearUserName()
+        cachedUserName = ""
     }
 }

--- a/data/src/main/java/com/prac/data/source/local/impl/UserLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/local/impl/UserLocalDataSourceImpl.kt
@@ -1,0 +1,21 @@
+package com.prac.data.source.local.impl
+
+import com.prac.data.source.local.UserLocalDataSource
+import com.prac.data.source.local.datastore.user.UserDataStoreManager
+import javax.inject.Inject
+
+internal class UserLocalDataSourceImpl @Inject constructor(
+    private val userDataStoreManager: UserDataStoreManager
+) : UserLocalDataSource {
+    override suspend fun setUserName(userName: String) {
+        userDataStoreManager.setUserName(userName)
+    }
+
+    override suspend fun getUserName(): String {
+        return userDataStoreManager.getUserName()
+    }
+
+    override suspend fun clearUserName() {
+        userDataStoreManager.clearUserName()
+    }
+}

--- a/data/src/main/java/com/prac/data/source/network/RepoStarApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/network/RepoStarApiDataSource.kt
@@ -1,7 +1,7 @@
 package com.prac.data.source.network
 
 internal interface RepoStarApiDataSource {
-    suspend fun checkRepositoryIsStarred(repoName: String)
+    suspend fun isStarred(userName: String, repoName: String)
 
     suspend fun starRepository(userName: String, repoName: String)
 

--- a/data/src/main/java/com/prac/data/source/network/UserApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/network/UserApiDataSource.kt
@@ -1,0 +1,5 @@
+package com.prac.data.source.network
+
+internal interface UserApiDataSource {
+    suspend fun getUserName(accessToken: String) : String
+}

--- a/data/src/main/java/com/prac/data/source/network/di/DataSourceModule.kt
+++ b/data/src/main/java/com/prac/data/source/network/di/DataSourceModule.kt
@@ -1,17 +1,19 @@
 package com.prac.data.source.network.di
 
-import com.prac.data.source.local.datastore.TokenDataStoreManagerImpl
-import com.prac.data.source.network.RepoApiDataSource
-import com.prac.data.source.network.RepoStarApiDataSource
-import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.local.TokenLocalDataSource
 import com.prac.data.source.local.datastore.TokenDataStoreManager
-import com.prac.data.source.network.service.GitHubService
-import com.prac.data.source.network.service.GitHubAuthService
+import com.prac.data.source.local.impl.TokenLocalDataSourceImpl
+import com.prac.data.source.network.AuthApiDataSource
+import com.prac.data.source.network.RepoApiDataSource
+import com.prac.data.source.network.RepoStarApiDataSource
+import com.prac.data.source.network.UserApiDataSource
+import com.prac.data.source.network.impl.AuthApiDataSourceImpl
 import com.prac.data.source.network.impl.RepoApiDataSourceImpl
 import com.prac.data.source.network.impl.RepoStarApiDataSourceImpl
-import com.prac.data.source.network.impl.AuthApiDataSourceImpl
-import com.prac.data.source.local.impl.TokenLocalDataSourceImpl
+import com.prac.data.source.network.impl.UserApiDataSourceImpl
+import com.prac.data.source.network.service.GitHubAuthService
+import com.prac.data.source.network.service.GitHubService
+import com.prac.data.source.network.service.GitHubUserService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -43,4 +45,10 @@ internal class DataSourceModule {
         gitHubService: GitHubService
     ): RepoStarApiDataSource =
         RepoStarApiDataSourceImpl(gitHubService)
+
+    @Provides
+    fun provideUserApiDataSource(
+        gitHubUserService: GitHubUserService
+    ): UserApiDataSource =
+        UserApiDataSourceImpl(gitHubUserService)
 }

--- a/data/src/main/java/com/prac/data/source/network/di/DataSourceModule.kt
+++ b/data/src/main/java/com/prac/data/source/network/di/DataSourceModule.kt
@@ -1,7 +1,7 @@
 package com.prac.data.source.network.di
 
 import com.prac.data.source.local.TokenLocalDataSource
-import com.prac.data.source.local.datastore.TokenDataStoreManager
+import com.prac.data.source.local.datastore.token.TokenDataStoreManager
 import com.prac.data.source.local.impl.TokenLocalDataSourceImpl
 import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.network.RepoApiDataSource

--- a/data/src/main/java/com/prac/data/source/network/di/DataSourceModule.kt
+++ b/data/src/main/java/com/prac/data/source/network/di/DataSourceModule.kt
@@ -1,8 +1,11 @@
 package com.prac.data.source.network.di
 
 import com.prac.data.source.local.TokenLocalDataSource
+import com.prac.data.source.local.UserLocalDataSource
 import com.prac.data.source.local.datastore.token.TokenDataStoreManager
+import com.prac.data.source.local.datastore.user.UserDataStoreManager
 import com.prac.data.source.local.impl.TokenLocalDataSourceImpl
+import com.prac.data.source.local.impl.UserLocalDataSourceImpl
 import com.prac.data.source.network.AuthApiDataSource
 import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
@@ -33,6 +36,12 @@ internal class DataSourceModule {
         tokenDataStoreManager: TokenDataStoreManager
     ): TokenLocalDataSource =
         TokenLocalDataSourceImpl(tokenDataStoreManager)
+
+    @Provides
+    fun provideUserLocalDataSource(
+        userDataStoreManager: UserDataStoreManager
+    ): UserLocalDataSource =
+        UserLocalDataSourceImpl(userDataStoreManager)
 
     @Provides
     fun provideRepoApiDataSource(

--- a/data/src/main/java/com/prac/data/source/network/di/RetrofitModule.kt
+++ b/data/src/main/java/com/prac/data/source/network/di/RetrofitModule.kt
@@ -4,10 +4,9 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFact
 import com.prac.data.BuildConfig
 import com.prac.data.source.network.di.annotation.AuthOkHttpClient
 import com.prac.data.source.network.di.annotation.BasicOkHttpClient
-import com.prac.data.source.network.di.annotation.AuthRetrofit
-import com.prac.data.source.network.di.annotation.BasicRetrofit
-import com.prac.data.source.network.service.GitHubService
-import com.prac.data.source.network.service.GitHubAuthService
+import com.prac.data.source.network.di.annotation.GitHubAuthRetrofit
+import com.prac.data.source.network.di.annotation.GitHubRetrofit
+import com.prac.data.source.network.di.annotation.GitHubUserRetrofit
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,8 +23,8 @@ import javax.inject.Singleton
 internal class RetrofitModule {
     @Provides
     @Singleton
-    @BasicRetrofit
-    fun provideGitHubTokenRetrofit(
+    @GitHubAuthRetrofit
+    fun provideGitHubAuthRetrofit(
         @BasicOkHttpClient okHttpClient: OkHttpClient
     ): Retrofit =
         Retrofit.Builder()
@@ -36,7 +35,7 @@ internal class RetrofitModule {
 
     @Provides
     @Singleton
-    @AuthRetrofit
+    @GitHubRetrofit
     fun provideGitHubRetrofit(
         @AuthOkHttpClient okHttpClient: OkHttpClient,
         converterFactory: Converter.Factory
@@ -49,15 +48,14 @@ internal class RetrofitModule {
 
     @Provides
     @Singleton
-    fun provideGitHubAuthService(
-        @BasicRetrofit retrofit: Retrofit
-    ): GitHubAuthService =
-        retrofit.create(GitHubAuthService::class.java)
-
-    @Provides
-    @Singleton
-    fun provideGitHubService(
-        @AuthRetrofit retrofit: Retrofit
-    ): GitHubService =
-        retrofit.create(GitHubService::class.java)
+    @GitHubUserRetrofit
+    fun provideUserRetrofit(
+        @BasicOkHttpClient okHttpClient: OkHttpClient,
+        converterFactory: Converter.Factory
+    ): Retrofit =
+        Retrofit.Builder()
+            .baseUrl(BuildConfig.GITHUB_API_URL)
+            .client(okHttpClient)
+            .addConverterFactory(converterFactory)
+            .build()
 }

--- a/data/src/main/java/com/prac/data/source/network/di/ServiceModule.kt
+++ b/data/src/main/java/com/prac/data/source/network/di/ServiceModule.kt
@@ -1,0 +1,39 @@
+package com.prac.data.source.network.di
+
+import com.prac.data.source.network.di.annotation.GitHubAuthRetrofit
+import com.prac.data.source.network.di.annotation.GitHubRetrofit
+import com.prac.data.source.network.di.annotation.GitHubUserRetrofit
+import com.prac.data.source.network.service.GitHubAuthService
+import com.prac.data.source.network.service.GitHubService
+import com.prac.data.source.network.service.GitHubUserService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal class ServiceModule {
+    @Provides
+    @Singleton
+    fun provideGitHubAuthService(
+        @GitHubAuthRetrofit retrofit: Retrofit
+    ): GitHubAuthService =
+        retrofit.create(GitHubAuthService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideGitHubService(
+        @GitHubRetrofit retrofit: Retrofit
+    ): GitHubService =
+        retrofit.create(GitHubService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideGitHubUserService(
+        @GitHubUserRetrofit retrofit: Retrofit
+    ): GitHubUserService =
+        retrofit.create(GitHubUserService::class.java)
+}

--- a/data/src/main/java/com/prac/data/source/network/di/annotation/RetrofitAnnotation.kt
+++ b/data/src/main/java/com/prac/data/source/network/di/annotation/RetrofitAnnotation.kt
@@ -4,8 +4,12 @@ import javax.inject.Qualifier
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class BasicRetrofit
+annotation class GitHubAuthRetrofit
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
-annotation class AuthRetrofit
+annotation class GitHubRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class GitHubUserRetrofit

--- a/data/src/main/java/com/prac/data/source/network/dto/AccessTokenRequest.kt
+++ b/data/src/main/java/com/prac/data/source/network/dto/AccessTokenRequest.kt
@@ -1,0 +1,9 @@
+package com.prac.data.source.network.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AccessTokenRequest(
+    @SerialName("access_token") val accessToken: String
+)

--- a/data/src/main/java/com/prac/data/source/network/dto/UserDto.kt
+++ b/data/src/main/java/com/prac/data/source/network/dto/UserDto.kt
@@ -1,0 +1,9 @@
+package com.prac.data.source.network.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class UserDto(
+    @SerialName("user") val user: OwnerDto = OwnerDto()
+)

--- a/data/src/main/java/com/prac/data/source/network/impl/RepoStarApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/RepoStarApiDataSourceImpl.kt
@@ -7,8 +7,8 @@ import javax.inject.Inject
 internal class RepoStarApiDataSourceImpl @Inject constructor(
     private val gitHubService: GitHubService
 ): RepoStarApiDataSource {
-    override suspend fun checkRepositoryIsStarred(repoName: String) {
-        gitHubService.checkRepositoryIsStarred("GongDoMin", repoName)
+    override suspend fun isStarred(userName: String, repoName: String) {
+        gitHubService.isStarred(userName, repoName)
     }
 
     override suspend fun starRepository(userName: String, repoName: String) {

--- a/data/src/main/java/com/prac/data/source/network/impl/UserApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/UserApiDataSourceImpl.kt
@@ -1,0 +1,16 @@
+package com.prac.data.source.network.impl
+
+import com.prac.data.source.network.UserApiDataSource
+import com.prac.data.source.network.dto.AccessTokenRequest
+import com.prac.data.source.network.service.GitHubUserService
+import javax.inject.Inject
+
+internal class UserApiDataSourceImpl @Inject constructor(
+    private val githubUserService: GitHubUserService
+) : UserApiDataSource {
+    override suspend fun getUserName(accessToken: String): String {
+        return githubUserService.getUserInformation(
+            accessToken = AccessTokenRequest(accessToken)
+        ).user.login
+    }
+}

--- a/data/src/main/java/com/prac/data/source/network/service/GitHubService.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/GitHubService.kt
@@ -23,7 +23,7 @@ internal interface GitHubService {
     ): RepoDetailDto
 
     @GET("user/starred/{userName}/{repoName}")
-    suspend fun checkRepositoryIsStarred(
+    suspend fun isStarred(
         @Path("userName") userName: String,
         @Path("repoName") repoName: String
     )

--- a/data/src/main/java/com/prac/data/source/network/service/GitHubUserService.kt
+++ b/data/src/main/java/com/prac/data/source/network/service/GitHubUserService.kt
@@ -1,0 +1,20 @@
+package com.prac.data.source.network.service
+
+import com.prac.data.BuildConfig
+import com.prac.data.source.network.dto.AccessTokenRequest
+import com.prac.data.source.network.dto.UserDto
+import okhttp3.Credentials
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+internal interface GitHubUserService {
+    @POST("applications/{clientID}/token")
+    suspend fun getUserInformation(
+        @Path("clientID") clientId: String = BuildConfig.CLIENT_ID,
+        @Header("Accept") accept: String = "application/json",
+        @Header("Authorization") authorization: String = Credentials.basic(BuildConfig.CLIENT_ID, BuildConfig.CLIENT_SECRET),
+        @Body accessToken: AccessTokenRequest
+    ) : UserDto
+}

--- a/data/src/main/proto/user.proto
+++ b/data/src/main/proto/user.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+option java_package = "com.prac.data.datastore";
+option java_multiple_files = true;
+
+message User {
+  string user_name = 1;
+}

--- a/data/src/test/java/com/prac/data/repository/TokenRepositoryTest.kt
+++ b/data/src/test/java/com/prac/data/repository/TokenRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.prac.data.repository
 
 import com.prac.data.exception.CommonException
 import com.prac.data.fake.source.local.FakeTokenLocalDataSource
+import com.prac.data.fake.source.local.FakeUserLocalDataSource
 import com.prac.data.fake.source.network.FakeAuthApiDataSource
 import com.prac.data.fake.source.network.FakeUserApiDataSource
 import com.prac.data.repository.impl.TokenRepositoryImpl
@@ -15,19 +16,15 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
 import java.io.IOException
 import java.time.ZonedDateTime
 
-@RunWith(MockitoJUnitRunner::class)
 class TokenRepositoryTest {
 
     private lateinit var tokenLocalDataSource: FakeTokenLocalDataSource
     private lateinit var authApiDataSource: FakeAuthApiDataSource
-    private lateinit var userApiDataSource: UserApiDataSource
-    @Mock private lateinit var userLocalDataSource: UserLocalDataSource
+    private lateinit var userApiDataSource: FakeUserApiDataSource
+    private lateinit var userLocalDataSource: FakeUserLocalDataSource
 
     private lateinit var tokenRepository: TokenRepository
 
@@ -39,6 +36,7 @@ class TokenRepositoryTest {
         tokenLocalDataSource = FakeTokenLocalDataSource()
         authApiDataSource = FakeAuthApiDataSource(token)
         userApiDataSource = FakeUserApiDataSource()
+        userLocalDataSource = FakeUserLocalDataSource()
         tokenRepository = TokenRepositoryImpl(
             tokenLocalDataSource = tokenLocalDataSource,
             authApiDataSource = authApiDataSource,
@@ -49,16 +47,19 @@ class TokenRepositoryTest {
 
     @Test
     fun authorizeOAuth_updateCacheAndReturnSuccess() = runTest {
+        val expectedUserName = "test"
 
         val result = tokenRepository.authorizeOAuth(code)
 
         val cache = tokenLocalDataSource.getToken()
+        val userName = userLocalDataSource.getUserName()
         assertEquals(cache.accessToken, token.accessToken)
         assertEquals(cache.refreshToken, token.refreshToken)
         assertEquals(cache.expiresInSeconds, token.expiresInSeconds)
         assertEquals(cache.refreshTokenExpiresInSeconds, token.refreshTokenExpiresInSeconds)
         assertEquals(cache.updatedAt, token.updatedAt)
         assertTrue(result.isSuccess)
+        assertEquals(userName, expectedUserName)
     }
 
     @Test

--- a/data/src/test/java/com/prac/data/repository/TokenRepositoryTest.kt
+++ b/data/src/test/java/com/prac/data/repository/TokenRepositoryTest.kt
@@ -3,8 +3,10 @@ package com.prac.data.repository
 import com.prac.data.exception.CommonException
 import com.prac.data.fake.source.local.FakeTokenLocalDataSource
 import com.prac.data.fake.source.network.FakeAuthApiDataSource
+import com.prac.data.fake.source.network.FakeUserApiDataSource
 import com.prac.data.repository.impl.TokenRepositoryImpl
 import com.prac.data.repository.model.TokenModel
+import com.prac.data.source.network.UserApiDataSource
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -19,6 +21,7 @@ class TokenRepositoryTest {
 
     private lateinit var tokenLocalDataSource: FakeTokenLocalDataSource
     private lateinit var authApiDataSource: FakeAuthApiDataSource
+    private lateinit var userApiDataSource: UserApiDataSource
 
     private lateinit var tokenRepository: TokenRepository
 
@@ -29,9 +32,11 @@ class TokenRepositoryTest {
     fun setUp() {
         tokenLocalDataSource = FakeTokenLocalDataSource()
         authApiDataSource = FakeAuthApiDataSource(token)
+        userApiDataSource = FakeUserApiDataSource()
         tokenRepository = TokenRepositoryImpl(
             tokenLocalDataSource = tokenLocalDataSource,
-            authApiDataSource = authApiDataSource
+            authApiDataSource = authApiDataSource,
+            userApiDataSource = userApiDataSource
         )
     }
 
@@ -150,7 +155,8 @@ class TokenRepositoryTest {
         authApiDataSource = FakeAuthApiDataSource(expiredToken)
         tokenRepository = TokenRepositoryImpl(
             tokenLocalDataSource = tokenLocalDataSource,
-            authApiDataSource = authApiDataSource
+            authApiDataSource = authApiDataSource,
+            userApiDataSource = userApiDataSource
         )
         tokenRepository.authorizeOAuth(code)
         Thread.sleep(1500)
@@ -175,7 +181,8 @@ class TokenRepositoryTest {
         authApiDataSource = FakeAuthApiDataSource(expiredToken)
         tokenRepository = TokenRepositoryImpl(
             tokenLocalDataSource = tokenLocalDataSource,
-            authApiDataSource = authApiDataSource
+            authApiDataSource = authApiDataSource,
+            userApiDataSource = userApiDataSource
         )
         tokenRepository.authorizeOAuth(code)
         Thread.sleep(1500)

--- a/data/src/test/java/com/prac/data/repository/TokenRepositoryTest.kt
+++ b/data/src/test/java/com/prac/data/repository/TokenRepositoryTest.kt
@@ -6,6 +6,7 @@ import com.prac.data.fake.source.network.FakeAuthApiDataSource
 import com.prac.data.fake.source.network.FakeUserApiDataSource
 import com.prac.data.repository.impl.TokenRepositoryImpl
 import com.prac.data.repository.model.TokenModel
+import com.prac.data.source.local.UserLocalDataSource
 import com.prac.data.source.network.UserApiDataSource
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -14,14 +15,19 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
 import java.io.IOException
 import java.time.ZonedDateTime
 
+@RunWith(MockitoJUnitRunner::class)
 class TokenRepositoryTest {
 
     private lateinit var tokenLocalDataSource: FakeTokenLocalDataSource
     private lateinit var authApiDataSource: FakeAuthApiDataSource
     private lateinit var userApiDataSource: UserApiDataSource
+    @Mock private lateinit var userLocalDataSource: UserLocalDataSource
 
     private lateinit var tokenRepository: TokenRepository
 
@@ -36,7 +42,8 @@ class TokenRepositoryTest {
         tokenRepository = TokenRepositoryImpl(
             tokenLocalDataSource = tokenLocalDataSource,
             authApiDataSource = authApiDataSource,
-            userApiDataSource = userApiDataSource
+            userApiDataSource = userApiDataSource,
+            userLocalDataSource = userLocalDataSource
         )
     }
 
@@ -156,7 +163,8 @@ class TokenRepositoryTest {
         tokenRepository = TokenRepositoryImpl(
             tokenLocalDataSource = tokenLocalDataSource,
             authApiDataSource = authApiDataSource,
-            userApiDataSource = userApiDataSource
+            userApiDataSource = userApiDataSource,
+            userLocalDataSource = userLocalDataSource
         )
         tokenRepository.authorizeOAuth(code)
         Thread.sleep(1500)
@@ -182,7 +190,8 @@ class TokenRepositoryTest {
         tokenRepository = TokenRepositoryImpl(
             tokenLocalDataSource = tokenLocalDataSource,
             authApiDataSource = authApiDataSource,
-            userApiDataSource = userApiDataSource
+            userApiDataSource = userApiDataSource,
+            userLocalDataSource = userLocalDataSource
         )
         tokenRepository.authorizeOAuth(code)
         Thread.sleep(1500)

--- a/data/src/test/java/com/prac/data/source/local/TokenLocalDataSourceTest.kt
+++ b/data/src/test/java/com/prac/data/source/local/TokenLocalDataSourceTest.kt
@@ -1,18 +1,14 @@
 package com.prac.data.source.local
 
 import com.prac.data.fake.source.local.FakeTokenDataStoreManager
-import com.prac.data.source.local.datastore.TokenDataStoreManager
-import com.prac.data.source.local.datastore.TokenLocalDto
+import com.prac.data.source.local.datastore.token.TokenDataStoreManager
+import com.prac.data.source.local.datastore.token.TokenLocalDto
 import com.prac.data.source.local.impl.TokenLocalDataSourceImpl
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime

--- a/data/src/test/java/com/prac/data/source/local/UserLocalDataSourceTest.kt
+++ b/data/src/test/java/com/prac/data/source/local/UserLocalDataSourceTest.kt
@@ -21,7 +21,7 @@ class UserLocalDataSourceTest {
     }
 
     @Test
-    fun getUserName_userNamePassedToDataSource() = runTest {
+    fun getCachedUserName_returnEmptyString_WhenDataStoreIsEmpty() = runTest {
         val expectedUserName = ""
 
         val result = userLocalDataSource.getUserName()
@@ -30,23 +30,27 @@ class UserLocalDataSourceTest {
     }
 
     @Test
-    fun setUserName_returnExpectedUserName() = runTest {
+    fun setUserName_updateCacheAndLocalData() = runTest {
         val expectedUserName = "test"
 
         userLocalDataSource.setUserName(expectedUserName)
 
-        val result = userLocalDataSource.getUserName()
-        assertEquals(result, expectedUserName)
+        val cache = userLocalDataSource.getUserName()
+        val local = userDataStoreManager.getUserName()
+        assertEquals(cache, expectedUserName)
+        assertEquals(local, expectedUserName)
     }
 
     @Test
-    fun clearUserName_returnEmptyString() = runTest {
+    fun clearUserName_updateCacheAndLocalData() = runTest {
         val userName = "test"
         userLocalDataSource.setUserName(userName)
 
         userLocalDataSource.clearUserName()
 
-        val result = userLocalDataSource.getUserName()
-        assertTrue(result.isEmpty())
+        val cache = userLocalDataSource.getUserName()
+        val local = userDataStoreManager.getUserName()
+        assertTrue(cache.isEmpty())
+        assertTrue(local.isEmpty())
     }
 }

--- a/data/src/test/java/com/prac/data/source/local/UserLocalDataSourceTest.kt
+++ b/data/src/test/java/com/prac/data/source/local/UserLocalDataSourceTest.kt
@@ -1,0 +1,52 @@
+package com.prac.data.source.local
+
+import com.prac.data.fake.source.local.FakeUserDataStoreManager
+import com.prac.data.source.local.datastore.user.UserDataStoreManager
+import com.prac.data.source.local.impl.UserLocalDataSourceImpl
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class UserLocalDataSourceTest {
+
+    private lateinit var userDataStoreManager: UserDataStoreManager
+    private lateinit var userLocalDataSource: UserLocalDataSource
+
+    @Before
+    fun setUp() {
+        userDataStoreManager = FakeUserDataStoreManager()
+        userLocalDataSource = UserLocalDataSourceImpl(userDataStoreManager)
+    }
+
+    @Test
+    fun getUserName_userNamePassedToDataSource() = runTest {
+        val expectedUserName = ""
+
+        val result = userLocalDataSource.getUserName()
+
+        assertEquals(result, expectedUserName)
+    }
+
+    @Test
+    fun setUserName_returnExpectedUserName() = runTest {
+        val expectedUserName = "test"
+
+        userLocalDataSource.setUserName(expectedUserName)
+
+        val result = userLocalDataSource.getUserName()
+        assertEquals(result, expectedUserName)
+    }
+
+    @Test
+    fun clearUserName_returnEmptyString() = runTest {
+        val userName = "test"
+        userLocalDataSource.setUserName(userName)
+
+        userLocalDataSource.clearUserName()
+
+        val result = userLocalDataSource.getUserName()
+        assertTrue(result.isEmpty())
+    }
+}

--- a/data/src/test/java/com/prac/data/source/network/RepoStarApiDataSourceTest.kt
+++ b/data/src/test/java/com/prac/data/source/network/RepoStarApiDataSourceTest.kt
@@ -26,9 +26,9 @@ class RepoStarApiDataSourceTest {
     fun checkRepositoryIsStarred_callGitHubService() = runTest {
         val repoName = "testRepo"
 
-        repoStarApiDataSource.checkRepositoryIsStarred(repoName)
+        repoStarApiDataSource.isStarred(repoName)
 
-        verify(gitHubService).checkRepositoryIsStarred("GongDoMin", repoName)
+        verify(gitHubService).isStarred("GongDoMin", repoName)
     }
 
     @Test

--- a/data/src/test/java/com/prac/data/source/network/UserApiDataSourceTest.kt
+++ b/data/src/test/java/com/prac/data/source/network/UserApiDataSourceTest.kt
@@ -1,0 +1,31 @@
+package com.prac.data.source.network
+
+import com.prac.data.fake.source.network.service.FakeGitHubUserService
+import com.prac.data.source.network.impl.UserApiDataSourceImpl
+import com.prac.data.source.network.service.GitHubUserService
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class UserApiDataSourceTest {
+
+    private lateinit var gitHubUserService: GitHubUserService
+    private lateinit var repoStarApiDataSource: UserApiDataSource
+
+    @Before
+    fun setUp() {
+        gitHubUserService = FakeGitHubUserService()
+        repoStarApiDataSource = UserApiDataSourceImpl(gitHubUserService)
+    }
+
+    @Test
+    fun getUser_userNamePassedToDataSource() = runTest {
+        val accessToken = "test"
+        val expectedUserName = "test"
+
+        val result = repoStarApiDataSource.getUserName(accessToken)
+
+        assertEquals(result, expectedUserName)
+    }
+}


### PR DESCRIPTION
notion - https://www.notion.so/feat-User-Api-User-DataStore-124a26591b6180fd9f9ce8d5d4fbc018?pvs=4

# AS-IS

- 현재 repository, repository star state 를 불러오는데 필요한 userName 이 하드코딩 되어 있다.
- User 정보를 불러오는 Service, DataSource, Repository 가 존재하지 않는다.
- User 정보를 저장하기 위한 DataStore 가 존재하지 않는다.

# TO-BE

```mermaid
sequenceDiagram 
	participant TokenRepository
	participant UserApiDataSource
	participant UserLocalDataSource
	participant UserService
	participant UserDataStore
	participant UserLocalDataSource
  
  TokenRepository ->> UserApiDataSource: getUserName
  UserApiDataSource ->> UserService: getUserName
  UserService ->> UserApiDataSource: userName
  UserApiDataSource ->> TokenRepository: userName
  TokenRepository ->> UserLocalDataSource: setUserName
  UserLocalDataSource ->> UserDataStore: setUserName

```

```mermaid
sequenceDiagram 
	participant RepoRepository
	participant UserLocalDataSource

  RepoRepository ->> UserLocalDataSource: getCachedUserName
  UserLocalDataSource ->> RepoRepository: cachedUserName 

```

- 기존에 존재했던 하드코딩된 userName 변경