### PR TITLE
refact: viewModel, ui test code 메서드명 및 로직 수정

### DIFF
--- a/app/src/androidTest/java/com/prac/githubrepo/login/LoginActivityTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/login/LoginActivityTest.kt
@@ -65,7 +65,7 @@ class LoginActivityTest {
     }
 
     @Test
-    fun testLoginButtonClick_startOAuthIntent() {
+    fun loginButtonClick_callLoginMethod() {
         onView(withId(R.id.btnLogin)).perform(click())
 
         intended(hasAction(Intent.ACTION_VIEW))
@@ -73,7 +73,7 @@ class LoginActivityTest {
     }
 
     @Test
-    fun testValidIntent_navigateToMainActivity() {
+    fun onNewIntent_validIntent_navigateToMainActivity() {
         val scheme = "githubrepo"
         val host = "localhost:8080"
         val code = "success"
@@ -87,7 +87,7 @@ class LoginActivityTest {
     }
 
     @Test
-    fun testInvalidIntent_showConnectionErrorDialog() {
+    fun onNewIntent_invalidIntent_showConnectionFailDialog() {
         val scheme = "githubrepo"
         val host = "localhost:8080"
         val code = "ioException"
@@ -107,7 +107,7 @@ class LoginActivityTest {
     }
 
     @Test
-    fun testInvalidIntent_showErrorDialog() {
+    fun onNewIntent_invalidIntent_showLoginFailDialog() {
         val scheme = "githubrepo"
         val host = "localhost:8080"
         val code = "else"

--- a/app/src/androidTest/java/com/prac/githubrepo/main/detail/DetailActivityTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/main/detail/DetailActivityTest.kt
@@ -3,6 +3,7 @@ package com.prac.githubrepo.main.detail
 import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.ImageView
+import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
@@ -62,6 +63,9 @@ class DetailActivityTest {
 
     @Test
     fun detailActivity_displayInUI() {
+        // 데이터 형식은 아래과 같음
+        // RepoEntity(id = 0, name = "test 0", owner = OwnerEntity("login 0", "avatarUrl 0"), stargazersCount = 5, updatedAt = "update", isStarred = true),
+        // RepoEntity(id = 1, name = "test 1", owner = OwnerEntity("login 1", "avatarUrl 1"), stargazersCount = 5, updatedAt = "update", isStarred = false),
         val clickPosition = 0
         val expectedRepoName = "test 0"
         val expectedUserName = "login 0"
@@ -80,9 +84,10 @@ class DetailActivityTest {
     }
 
     @Test
-    fun detailActivity_clickStarImageView() {
+    fun clickStarImageView_starImageDrawableToUnStarImageDrawable_and_starCountMinusOne() {
         val clickPosition = 0
         val expectedStarDrawable = unStarDrawable
+        val expectedStarCount = 4
         onView(withId(R.id.rvMain))
             .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(clickPosition, ViewActions.click()))
         intended(hasComponent(DetailActivity::class.java.name))
@@ -90,12 +95,15 @@ class DetailActivityTest {
         onView(withId(R.id.ivStar))
             .perform(waitForImageChange())
             .check(matches(matchesImageViewDrawable(expectedStarDrawable)))
+        onView(withId(R.id.tvStarCount))
+            .check(matches(matchesStarCount(expectedStarCount)))
     }
 
     @Test
-    fun detailActivity_clickStarUnImageView() {
+    fun clickUnStarImageView_unStarImageDrawableToStarImageDrawable_and_starCountPlusOne() {
         val clickPosition = 1
         val expectedStarDrawable = starDrawable
+        val expectedStarCount = 6
         onView(withId(R.id.rvMain))
             .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>(clickPosition, ViewActions.click()))
         intended(hasComponent(DetailActivity::class.java.name))
@@ -103,12 +111,21 @@ class DetailActivityTest {
         onView(withId(R.id.ivStar))
             .perform(waitForImageChange())
             .check(matches(matchesImageViewDrawable(expectedStarDrawable)))
+        onView(withId(R.id.tvStarCount))
+            .check(matches(matchesStarCount(expectedStarCount)))
     }
 
     private fun matchesImageViewDrawable(drawable: Drawable): Matcher<View> {
         return object : CustomTypeSafeMatcher<View>("get matched view is ImageView and view drawable") {
             override fun matchesSafely(item: View): Boolean =
                 (item as ImageView).drawable?.constantState == drawable.constantState
+        }
+    }
+
+    private fun matchesStarCount(expectedStarCount: Int): Matcher<View> {
+        return object : CustomTypeSafeMatcher<View>("get matched view is ImageView and view drawable") {
+            override fun matchesSafely(item: View): Boolean =
+                (item as TextView).text == "별 ${expectedStarCount}개"
         }
     }
 

--- a/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/login/LoginViewModelTest.kt
@@ -26,8 +26,7 @@ class LoginViewModelTest {
 
     @Test
     fun checkAutoLogin_userIsLoggedIn_eventSuccess() = runTest {
-        tokenRepository = FakeTokenRepository()
-        tokenRepository.setInitialToken()
+        tokenRepository = FakeTokenRepository().apply { setInitialToken() }
         loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
 
         val result = loginViewModel.event.first()
@@ -36,7 +35,7 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun checkAutoLogin_userIsNotLoggedIn() = runTest {
+    fun checkAutoLogin_userIsNotLoggedIn_eventIsNotChanged() = runTest {
         tokenRepository = FakeTokenRepository()
         loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
 
@@ -47,22 +46,24 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun loginWithGitHub_updateSuccessEvent() = runTest {
+    fun loginWithGitHub_apiCallIsSuccess_successEvent() = runTest {
+        val code = "success"
         tokenRepository = FakeTokenRepository()
         loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
 
-        loginViewModel.loginWithGitHub("success")
+        loginViewModel.loginWithGitHub(code)
 
         val event = loginViewModel.event.first()
         assertTrue(event is LoginViewModel.Event.Success)
     }
 
     @Test
-    fun loginWithGitHub_networkError_updateUiStateToError() = runTest {
+    fun loginWithGitHub_apiCallIsNetworkError_uiStateIsError() = runTest {
+        val code = "ioException"
         tokenRepository = FakeTokenRepository()
         loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
 
-        loginViewModel.loginWithGitHub("ioException")
+        loginViewModel.loginWithGitHub(code)
         advanceUntilIdle()
 
         val uiState = loginViewModel.uiState.value
@@ -71,11 +72,12 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun loginWithGitHub_authorizationError_updateUiStateToError() = runTest {
+    fun loginWithGitHub_apiCallIsAuthorizationError_uiStateIsError() = runTest {
+        val code = "else"
         tokenRepository = FakeTokenRepository()
         loginViewModel = LoginViewModel(tokenRepository, standardTestDispatcherRule.testDispatcher)
 
-        loginViewModel.loginWithGitHub("else")
+        loginViewModel.loginWithGitHub(code)
         advanceUntilIdle()
 
         val uiState = loginViewModel.uiState.value

--- a/data/src/main/java/com/prac/data/fake/FakeRepoRepository.kt
+++ b/data/src/main/java/com/prac/data/fake/FakeRepoRepository.kt
@@ -101,7 +101,7 @@ class FakeRepoRepository @Inject constructor(
         }
 
         try {
-            val response = makeRepoEntityList(page - 1)
+            val response = makeRepoEntityList(page)
 
             repositoryDatabase.withTransaction {
                 if (loadType == LoadType.REFRESH) {
@@ -152,7 +152,14 @@ class FakeRepoRepository @Inject constructor(
 
         repeat(10) {
             pagingData.add(
-                RepoEntity(id = it + (10 * page), name = "test ${it + (10 * page)}", owner = OwnerEntity("login ${it + (10 * page)}", "avatarUrl ${it + (10 * page)}"), stargazersCount = 5, updatedAt = "update", isStarred = null)
+                RepoEntity(
+                    id = it + (10 * (page - 1)),
+                    name = "test ${it + (10 * (page - 1))}",
+                    owner = OwnerEntity("login ${it + (10 * (page - 1))}", "avatarUrl ${it + (10 * (page - 1))}"),
+                    stargazersCount = 5,
+                    updatedAt = "update",
+                    isStarred = null
+                )
             )
         }
         // listOf(


### PR DESCRIPTION
notion - https://www.notion.so/refact-viewModel-ui-test-code-126a26591b61806eae6dc52c78757c39?pvs=4

# AS-IS

- 현재 테스트코드 메서드명이 일관되지 않음.

# TO-BE

- 메서드명_테스트상태_기대결과 로 변경
- 일부 로직 수정