### PR TITLE
fix: MainViewModelTest 오류 수정 및 사용하지 않는 sealed class 제거

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -45,24 +45,8 @@ class DetailViewModel @Inject constructor(
         ) : UiState()
     }
 
-    sealed class SideEffect {
-        data object BasicDialogDismiss : SideEffect() // IOException, 404 에러의 alert dialog 가 dismiss 되는 경우
-        data object LogoutDialogDismiss : SideEffect()
-        data class StarClick(val repoDetailEntity: RepoDetailEntity) : SideEffect()
-        data class UnStarClick(val repoDetailEntity: RepoDetailEntity) : SideEffect()
-    }
-
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
-
-    private val _sideEffect = MutableSharedFlow<SideEffect>()
-    val sideEffect = _sideEffect.asSharedFlow()
-
-    fun setSideEffect(sideEffect: SideEffect) {
-        viewModelScope.launch {
-            _sideEffect.emit(sideEffect)
-        }
-    }
 
     fun getRepository(userName: String?, repoName: String?) {
         if (_uiState.value != UiState.Idle) return

--- a/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/MainViewModelTest.kt
@@ -42,7 +42,6 @@ class MainViewModelTest {
 
     private lateinit var mainViewModel: MainViewModel
 
-
     @Before
     fun setUp() = runTest {
         tokenRepository = FakeTokenRepository().apply { setInitialToken() }
@@ -58,15 +57,6 @@ class MainViewModelTest {
     fun tearDown() {
         backOffWork.clearWork()
         backOffWork.clearDelayTimes()
-    }
-
-    @Test
-    fun getRepositories_getRepositoriesIsSuccess_updateUiStateToContent() = runTest {
-        advanceUntilIdle()
-
-        val result = mainViewModel.uiState.value
-
-        assertTrue(result is MainViewModel.UiState.Content)
     }
 
     @Test
@@ -137,8 +127,7 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         val uiState = mainViewModel.uiState.value
-        assertTrue(uiState is MainViewModel.UiState.Content)
-        assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, INVALID_TOKEN)
+        assertEquals(uiState.dialogMessage, INVALID_TOKEN)
     }
 
     @Test
@@ -151,8 +140,7 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         val uiState = mainViewModel.uiState.value
-        assertTrue(uiState is MainViewModel.UiState.Content)
-        assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, INVALID_TOKEN)
+        assertEquals(uiState.dialogMessage, INVALID_TOKEN)
     }
 
     @Test
@@ -165,8 +153,7 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         val uiState = mainViewModel.uiState.value
-        assertTrue(uiState is MainViewModel.UiState.Content)
-        assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, INVALID_REPOSITORY)
+        assertEquals(uiState.dialogMessage, INVALID_REPOSITORY)
         verify(mockRepoRepository).unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
     }
 
@@ -180,8 +167,7 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         val uiState = mainViewModel.uiState.value
-        assertTrue(uiState is MainViewModel.UiState.Content)
-        assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, INVALID_REPOSITORY)
+        assertEquals(uiState.dialogMessage, INVALID_REPOSITORY)
         verify(mockRepoRepository).starLocalRepository(repoEntity.id, repoEntity.stargazersCount)
     }
 
@@ -196,8 +182,7 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         val uiState = mainViewModel.uiState.value
-        assertTrue(uiState is MainViewModel.UiState.Content)
-        assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, UNKNOWN)
+        assertEquals(uiState.dialogMessage, UNKNOWN)
         verify(mockRepoRepository).unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount)
     }
 
@@ -212,8 +197,7 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         val uiState = mainViewModel.uiState.value
-        assertTrue(uiState is MainViewModel.UiState.Content)
-        assertEquals((uiState as MainViewModel.UiState.Content).dialogMessage, UNKNOWN)
+        assertEquals(uiState.dialogMessage, UNKNOWN)
         verify(mockRepoRepository).starLocalRepository(repoEntity.id, repoEntity.stargazersCount)
     }
 
@@ -223,6 +207,7 @@ class MainViewModelTest {
             name = "name",
             owner = OwnerEntity(login = "login", avatarUrl = "avatarUrl"),
             stargazersCount = 10,
+            defaultBranch = "master",
             updatedAt = "updatedAt",
             isStarred = null
         )


### PR DESCRIPTION
# AS-IS

- 기존의 MainViewModel UiState sealed class 변경을 했지만 MainViewModelTest 에 적용하지 못했음
- DetailViewModel 에 사용하지 않는 SideEffect sealed class 가 존재함

# TO-BE

- MainViewModelTest UiState 관련 에러 처리
- DetailViewModel SideEffect sealed class 제거