### PR TITLE
feat: SettingScreen 및 SettingViewModel 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,4 +110,5 @@ dependencies {
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.androidx.paging.compose)
     implementation(libs.compose)
+    implementation(libs.compose.constraintLayout)
 }

--- a/app/src/androidTest/java/com/prac/githubrepo/main/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/main/MainScreenTest.kt
@@ -177,7 +177,8 @@ class MainScreenTest {
                     isDetailScreen = true
                     this.userName = userName
                     this.repoName = repoName
-                }
+                },
+                onClickSetting = { }
             )
         }
     }

--- a/app/src/main/java/com/prac/githubrepo/NavGraph.kt
+++ b/app/src/main/java/com/prac/githubrepo/NavGraph.kt
@@ -13,6 +13,7 @@ import com.prac.githubrepo.DetailArgs.USER_NAME_ARG
 import com.prac.githubrepo.login.LoginScreen
 import com.prac.githubrepo.main.MainScreen
 import com.prac.githubrepo.main.detail.DetailScreen
+import com.prac.githubrepo.main.setting.SettingScreen
 
 @Composable
 fun NavGraph(
@@ -37,7 +38,8 @@ fun NavGraph(
         ) {
             MainScreen(
                 onLogout = { navActions.navigationToLogin() },
-                onClickRepository = { userName, repoName -> navActions.navigateMainToDetail(userName, repoName) }
+                onClickRepository = { userName, repoName -> navActions.navigateMainToDetail(userName, repoName) },
+                onClickSetting = { navActions.navigateMainToSetting() }
             )
         }
 
@@ -53,6 +55,14 @@ fun NavGraph(
                 onBack = { navActions.navigationLoginToMain() },
                 userName = entry.arguments?.getString(USER_NAME_ARG),
                 repoName = entry.arguments?.getString(REPO_NAME_ARG)
+            )
+        }
+
+        composable(
+            route = Destinations.SETTING_SCREEN
+        ) {
+            SettingScreen(
+                onLogout = { navActions.navigationToLogin() }
             )
         }
     }

--- a/app/src/main/java/com/prac/githubrepo/Navigation.kt
+++ b/app/src/main/java/com/prac/githubrepo/Navigation.kt
@@ -8,6 +8,7 @@ private object Screens {
     const val LOGIN_SCREEN = "login"
     const val MAIN_SCREEN = "main"
     const val DETAIL_SCREEN = "detail"
+    const val SETTING_SCREEN = "setting"
 }
 
 object DetailArgs {
@@ -19,6 +20,7 @@ object Destinations {
     const val LOGIN_SCREEN = Screens.LOGIN_SCREEN
     const val MAIN_SCREEN = Screens.MAIN_SCREEN
     const val DETAIL_SCREEN = "${Screens.DETAIL_SCREEN}?${USER_NAME_ARG}={${USER_NAME_ARG}}&${REPO_NAME_ARG}={${REPO_NAME_ARG}}"
+    const val SETTING_SCREEN = Screens.SETTING_SCREEN
 }
 
 class NavigationActions(private val navController: NavHostController) {
@@ -40,5 +42,9 @@ class NavigationActions(private val navController: NavHostController) {
         navController.navigate(
             route
         )
+    }
+
+    fun navigateMainToSetting() {
+        navController.navigate(Screens.SETTING_SCREEN)
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainScreen.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.CircularProgressIndicator
@@ -19,12 +20,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
+import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.CombinedLoadStates
@@ -44,7 +47,8 @@ import com.prac.githubrepo.util.drawableID
 fun MainScreen(
     viewModel: MainViewModel = hiltViewModel(),
     onLogout: () -> Unit,
-    onClickRepository: (String, String) -> Unit
+    onClickRepository: (String, String) -> Unit,
+    onClickSetting: () -> Unit
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -55,6 +59,7 @@ fun MainScreen(
         onClickStar = viewModel::unStarRepository,
         onClickUnStar = viewModel::starRepository,
         onClickRepository = { onClickRepository(it.owner.login, it.name) },
+        onClickSetting = onClickSetting,
         onDismissRequest = { dialogMessage -> if (dialogMessage == INVALID_TOKEN) onLogout() }
     )
 }
@@ -67,16 +72,18 @@ fun MainContent(
     onClickStar: (RepoEntity) -> Unit,
     onClickUnStar: (RepoEntity) -> Unit,
     onClickRepository: (RepoEntity) -> Unit,
+    onClickSetting: () -> Unit,
     onDismissRequest: (String) -> Unit
 ) {
     val repositories = uiState.repositories.collectAsLazyPagingItems()
 
     Column(
         modifier = Modifier
-            .fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .fillMaxSize()
     ) {
-        MainContentTitle()
+        MainContentHeader(
+            onClickSetting = onClickSetting
+        )
 
         MainContentBody(
             repositories = repositories,
@@ -97,14 +104,48 @@ fun MainContent(
 }
 
 @Composable
-fun MainContentTitle() {
-    Text(
+fun MainContentHeader(
+    onClickSetting: () -> Unit
+) {
+    ConstraintLayout(
         modifier = Modifier
-            .padding(
-                top = dimensionResource(id = R.dimen.padding_normal)
-            ),
-        text = stringResource(id = R.string.repository)
-    )
+            .fillMaxWidth()
+    ) {
+        val (text, image, divider) = createRefs()
+
+        Text(
+            text = stringResource(id = R.string.repository),
+            modifier = Modifier.constrainAs(text) {
+                centerHorizontallyTo(parent)
+                centerVerticallyTo(parent)
+            }
+        )
+
+        Image(
+            painter = painterResource(id = R.drawable.img_glide_profile),
+            contentDescription = null,
+            modifier = Modifier
+                .padding(dimensionResource(id = R.dimen.padding_normal))
+                .size(dimensionResource(id = R.dimen.user_profile))
+                .clip(CircleShape)
+                .constrainAs(image) {
+                    end.linkTo(parent.end)
+                    centerVerticallyTo(parent)
+                }
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onClickSetting
+                )
+        )
+
+        HorizontalDivider(
+            modifier = Modifier
+                .constrainAs(divider) {
+                    bottom.linkTo(parent.bottom)
+                }
+        )
+    }
 }
 
 @Composable
@@ -256,7 +297,10 @@ fun MainContentItemStar(
                         else onClickUnStar(repo)
                     }
                 )
-                .semantics { drawableID = if (repo.isStarred == true) R.drawable.img_star else R.drawable.img_unstar },
+                .semantics {
+                    drawableID =
+                        if (repo.isStarred == true) R.drawable.img_star else R.drawable.img_unstar
+                },
             painter = painterResource(id = if (repo.isStarred == true) R.drawable.img_star else R.drawable.img_unstar),
             contentDescription = null
         )

--- a/app/src/main/java/com/prac/githubrepo/main/MainScreenPreview.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainScreenPreview.kt
@@ -30,6 +30,7 @@ fun MainScreenPreview() {
         onClickStar = { },
         onClickUnStar = { },
         onClickRepository = { },
+        onClickSetting = { },
         onDismissRequest = { }
     )
 }
@@ -49,6 +50,7 @@ fun MainScreenNetworkFailurePreview() {
         onClickStar = { },
         onClickUnStar = { },
         onClickRepository = { },
+        onClickSetting = { },
         onDismissRequest = { }
     )
 }
@@ -68,6 +70,7 @@ fun MainScreenAuthorizationErrorPreview() {
         onClickStar = { },
         onClickUnStar = { },
         onClickRepository = { },
+        onClickSetting = { },
         onDismissRequest = { }
     )
 }
@@ -87,6 +90,7 @@ fun MainScreenNotFoundRepositoryErrorPreview() {
         onClickStar = { },
         onClickUnStar = { },
         onClickRepository = { },
+        onClickSetting = { },
         onDismissRequest = { }
     )
 }

--- a/app/src/main/java/com/prac/githubrepo/main/setting/SettingPreview.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/setting/SettingPreview.kt
@@ -1,0 +1,41 @@
+package com.prac.githubrepo.main.setting
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(showBackground = true)
+@Composable
+fun SettingContentIsLoadingPreview() {
+    SettingContent(
+        isLoading = true,
+        dialogMessage = "",
+        onClickLogoutButton = { },
+        onClickCheckButton = { },
+        onDismissRequest = { }
+    )
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun SettingContentPreview() {
+    SettingContent(
+        isLoading = false,
+        dialogMessage = "",
+        onClickLogoutButton = { },
+        onClickCheckButton = { },
+        onDismissRequest = { }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SettingContentDialogPreview() {
+    SettingContent(
+        isLoading = false,
+        dialogMessage = "정말 로그아웃하시겠습니까?",
+        onClickLogoutButton = { },
+        onClickCheckButton = { },
+        onDismissRequest = { }
+    )
+}

--- a/app/src/main/java/com/prac/githubrepo/main/setting/SettingScreen.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/setting/SettingScreen.kt
@@ -1,0 +1,119 @@
+package com.prac.githubrepo.main.setting
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import com.prac.githubrepo.R
+import com.prac.githubrepo.util.BasicAlertDialog
+import com.prac.githubrepo.util.LoadingContent
+import com.prac.githubrepo.util.bounceClick
+import com.prac.githubrepo.util.buttonID
+
+@Composable
+fun SettingScreen(
+    viewModel: SettingViewModel = hiltViewModel(),
+    onLogout: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val activity = LocalContext.current as ComponentActivity
+
+    SettingContent(
+        isLoading = uiState is SettingViewModel.UiState.Loading,
+        dialogMessage = (uiState as? SettingViewModel.UiState.Dialog)?.message ?: "",
+        onClickLogoutButton = {
+            viewModel.setUiState(SettingViewModel.UiState.Dialog(message = "정말 로그아웃하시겠습니까?"))
+        },
+        onClickCheckButton = { viewModel.logout() },
+        onDismissRequest = { viewModel.setUiState(SettingViewModel.UiState.Idle) }
+    )
+
+    LaunchedEffect(Unit) {
+        activity.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.event.collect {
+                onLogout()
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingContent(
+    isLoading: Boolean,
+    dialogMessage: String,
+    onClickLogoutButton: () -> Unit,
+    onClickCheckButton: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    LoadingContent(
+        isLoading = isLoading
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    start = dimensionResource(id = R.dimen.padding_normal),
+                    end = dimensionResource(id = R.dimen.padding_normal)
+                ),
+            verticalArrangement = Arrangement.Center
+        ) {
+            LogoutButton(
+                onClickLogout = onClickLogoutButton
+            )
+        }
+
+        if (dialogMessage.isNotEmpty()) {
+            BasicAlertDialog(
+                onDismissRequest = onDismissRequest,
+                onClickCheckButton = onClickCheckButton,
+                dialogMessage = dialogMessage
+            )
+        }
+    }
+}
+
+@Composable
+fun LogoutButton(
+    onClickLogout: () -> Unit
+) {
+    Button(
+        onClick = onClickLogout,
+        modifier = Modifier
+            .fillMaxWidth()
+            .bounceClick()
+            .semantics { buttonID = R.string.logout },
+        colors = ButtonColors(
+            containerColor = Color.Black,
+            contentColor = Color.White,
+            disabledContainerColor = Color.Gray,
+            disabledContentColor = Color.White
+        )
+    ) {
+        Text(
+            modifier = Modifier
+                .padding(
+                    top = dimensionResource(id = R.dimen.padding_small),
+                    bottom = dimensionResource(id = R.dimen.padding_small)
+                ),
+            text = stringResource(id = R.string.logout)
+        )
+    }
+}

--- a/app/src/main/java/com/prac/githubrepo/main/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/setting/SettingViewModel.kt
@@ -1,0 +1,61 @@
+package com.prac.githubrepo.main.setting
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.prac.data.repository.RepoRepository
+import com.prac.data.repository.TokenRepository
+import com.prac.githubrepo.di.IODispatcher
+import com.prac.githubrepo.util.BackOffWorkManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingViewModel @Inject constructor(
+    private val tokenRepository: TokenRepository,
+    private val repoRepository: RepoRepository,
+    @IODispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val backOffWorkManager: BackOffWorkManager
+) : ViewModel() {
+    sealed class UiState {
+        data object Idle : UiState()
+
+        data object Loading : UiState()
+
+        data class Dialog(
+            val message : String
+        ) : UiState()
+    }
+
+    sealed class Event {
+        data object Success : Event()
+    }
+
+    private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
+    val uiState = _uiState.asStateFlow()
+
+    private val _event = MutableSharedFlow<Event>()
+    val event = _event.asSharedFlow()
+
+    fun setUiState(uiState: UiState) {
+        _uiState.update { uiState }
+    }
+
+    fun logout() {
+        viewModelScope.launch(ioDispatcher) {
+            _uiState.update { UiState.Loading }
+
+            tokenRepository.clearToken()
+            backOffWorkManager.clearWork()
+            repoRepository.clearRepositories()
+
+            _event.emit(Event.Success)
+        }
+    }
+}

--- a/app/src/main/java/com/prac/githubrepo/util/AlertDialog.kt
+++ b/app/src/main/java/com/prac/githubrepo/util/AlertDialog.kt
@@ -39,3 +39,48 @@ fun ErrorAlertDialog(
         }
     )
 }
+
+@Composable
+fun BasicAlertDialog(
+    onDismissRequest: () -> Unit,
+    onClickCheckButton: () -> Unit,
+    dialogMessage: String
+) {
+    AlertDialog(
+        modifier = Modifier
+            .fillMaxWidth(),
+        onDismissRequest = onDismissRequest,
+        text = { Text(dialogMessage) }, // 내용
+        confirmButton = {
+            Button(
+                onClick = onDismissRequest,
+                colors = ButtonColors(
+                    containerColor = Color.Red,
+                    contentColor = Color.White,
+                    disabledContainerColor = Color.Red.copy(alpha = 0.3f),
+                    disabledContentColor = Color.White
+                )
+            ) {
+                Text(
+                    text = stringResource(id = R.string.cancel),
+                    color = Color.White
+                )
+            }
+
+            Button(
+                onClick = onClickCheckButton,
+                colors = ButtonColors(
+                    containerColor = Color.Black,
+                    contentColor = Color.White,
+                    disabledContainerColor = Color.Gray,
+                    disabledContentColor = Color.White
+                )
+            ) {
+                Text(
+                    text = stringResource(id = R.string.check),
+                    color = Color.White
+                )
+            }
+        }
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,17 +2,15 @@
     <string name="app_name">Github Repo</string>
 
     <string name="check">확인</string>
+    <string name="cancel">취소</string>
 
     <string name="retry">재시도</string>
 
     <string name="login">로그인</string>
+    <string name="logout">로그아웃</string>
     <string name="login_description">개인 계정을 사용해서 GitHub.com 에 로그인</string>
-    <string name="login_github_login">GitHub Login</string>
 
     <string name="repository">레파지토리</string>
-    <string name="main_title">Repository</string>
-
-    <string name="requestID">requestID</string>
 
     <string name="star_count">별 %d개</string>
     <string name="fork_count">포크 %d개</string>

--- a/data/src/main/java/com/prac/data/fake/FakeRepoRepository.kt
+++ b/data/src/main/java/com/prac/data/fake/FakeRepoRepository.kt
@@ -56,6 +56,11 @@ class FakeRepoRepository @Inject constructor(
         return Result.success(entity)
     }
 
+    override suspend fun clearRepositories() {
+        repositoryDatabase.repositoryDao().clearRepositories()
+        repositoryDatabase.remoteKeyDao().clearRemoteKeys()
+    }
+
     override suspend fun getStarStateAndStarCount(id: Int): Flow<Pair<Boolean?, Int?>> {
         return repositoryDatabase.repositoryDao().getRepository(id).map { Pair(it?.isStarred, it?.stargazersCount) }
     }

--- a/data/src/main/java/com/prac/data/repository/RepoRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/RepoRepository.kt
@@ -14,6 +14,8 @@ abstract class RepoRepository : RemoteMediator<Int, Repository>() {
 
     abstract suspend fun getRepository(userName: String, repoName: String) : Result<RepoDetailEntity>
 
+    abstract suspend fun clearRepositories()
+
     abstract suspend fun getStarStateAndStarCount(id: Int) : Flow<Pair<Boolean?, Int?>>
 
     abstract suspend fun isStarred(id: Int, repoName: String)

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -72,6 +72,11 @@ internal class RepoRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun clearRepositories() {
+        repositoryDatabase.repositoryDao().clearRepositories()
+        repositoryDatabase.remoteKeyDao().clearRemoteKeys()
+    }
+
     override suspend fun getStarStateAndStarCount(id: Int): Flow<Pair<Boolean?, Int?>> {
         return repositoryDatabase.repositoryDao().getRepository(id).map { Pair(it?.isStarred, it?.stargazersCount) }
     }

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -45,6 +45,7 @@ internal class TokenRepositoryImpl @Inject constructor(
 
     override suspend fun clearToken() {
         tokenLocalDataSource.clearToken()
+        userLocalDataSource.clearUserName()
     }
 
     override suspend fun refreshToken(refreshToken: String): Result<Unit> {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ datastore-preferences = "1.0.0"
 protobuf-javalite = "3.18.0"
 paging = "3.3.1"
 room = "2.6.1"
+compose-constraintLayout= "1.0.1"
 
 # plugins
 kapt = "1.5.30"
@@ -62,6 +63,7 @@ androidx-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedat
 androidx-ui = { module = "androidx.compose.ui:ui" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose = { module = "com.github.bumptech.glide:compose", version.ref = "compose" }
+compose-constraintLayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "compose-constraintLayout" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltAndroidTesting" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hiltAndroidTesting" }


### PR DESCRIPTION
notion - https://www.notion.so/feat-SettingScreen-SettingViewModel-12da26591b61801484e5d299ce345d64?pvs=4

# AS-IS

- 현재 로그아웃을 위한 스크린이 존재하지 않다.
- 현재 메인페이지에서 Setting Screen 으로 가기 위한 ui 가 존재하지 않는다.
- 로그아웃할 때 room 에 존재하는 repository, remoteKey 를 제거하기 위한 레파지토리 메서드가 존재하지 않는다.

# TO-BE

- SettingScreen 추가
- SettingViewModel 추가
- SettingScreen 에서 사용하기 위한 AlertDialog 컴포즈 함수 추가
- MainScreen 에서 SettingScreen 으로 가기 위한 ui 추가
- NavigationAction 및 NavGraph 추가