### PR TITLE
feat: SettingScreen, SettingViewModel, navGraph 테스트 코드 추가

### DIFF
--- a/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
@@ -2,19 +2,30 @@ package com.prac.githubrepo
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onChild
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
+import androidx.compose.ui.test.printToLog
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
+import com.prac.githubrepo.util.hasButton
 import com.prac.githubrepo.util.hasDrawable
+import com.prac.githubrepo.util.hasIcon
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.test.runTest
@@ -105,6 +116,36 @@ class NavigationTest {
         composeTestRule.onNode(hasDrawable(R.drawable.img_star)).assertIsDisplayed()
         composeTestRule.onNode(hasDrawable(R.drawable.img_fork)).assertIsDisplayed()
         composeTestRule.onAllNodesWithText(expectedRepoDetail.stargazersCount.toString()).assertCountEquals(2)
+
+        pressBack()
+
+        composeTestRule.onNodeWithText(activity.getString(R.string.repository)).assertIsDisplayed()
+    }
+
+    @Test
+    fun navigationMainToSettingTest() = runTest {
+        composeTestRule.setContent {
+            NavGraph(startDestination = Destinations.MAIN_SCREEN)
+        }
+
+        composeTestRule
+            .onNode(hasIcon(Icons.Default.AccountCircle))
+            .performClick()
+
+        composeTestRule.onNode(hasButton(R.string.logout)).assertIsDisplayed()
+    }
+
+    @Test
+    fun navigationSettingToMainTest() = runTest {
+        composeTestRule.setContent {
+            NavGraph(startDestination = Destinations.MAIN_SCREEN)
+        }
+
+        composeTestRule
+            .onNode(hasIcon(Icons.Default.AccountCircle))
+            .performClick()
+
+        composeTestRule.onNode(hasButton(R.string.logout)).assertIsDisplayed()
 
         pressBack()
 

--- a/app/src/androidTest/java/com/prac/githubrepo/main/setting/SettingScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/main/setting/SettingScreenTest.kt
@@ -1,0 +1,102 @@
+package com.prac.githubrepo.main.setting
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isNotDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.prac.data.repository.RepoRepository
+import com.prac.data.repository.TokenRepository
+import com.prac.githubrepo.MainActivity
+import com.prac.githubrepo.R
+import com.prac.githubrepo.util.BackOffWorkManager
+import com.prac.githubrepo.util.hasButton
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.inject.Inject
+
+@RunWith(AndroidJUnit4::class)
+@HiltAndroidTest
+class SettingScreenTest {
+
+    @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    private val activity get() = composeTestRule.activity
+
+    private var isMainScreen = false
+
+    @Inject
+    lateinit var tokenRepository: TokenRepository
+    @Inject
+    lateinit var repoRepository: RepoRepository
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+        setContent()
+    }
+
+    @Test
+    fun displaySettingScreen_whenUiStateIsIdle() {
+        composeTestRule.onNode(hasButton(R.string.logout)).assertIsDisplayed()
+        composeTestRule.onNodeWithText(activity.getString(R.string.logout)).assertIsDisplayed()
+    }
+
+    @Test
+    fun loginButtonClick_showLogoutAlertDialog() = runTest {
+        composeTestRule.onNode(hasButton(R.string.logout)).performClick()
+
+        composeTestRule.onNodeWithText(activity.getString(R.string.logout_confirm)).assertIsDisplayed()
+    }
+
+    @Test
+    fun loginButtonClick_showLogoutAlertDialog_cancelButtonClick() = runTest {
+        composeTestRule.onNode(hasButton(R.string.logout)).performClick()
+
+        composeTestRule.onNodeWithText(activity.getString(R.string.logout_confirm)).assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(activity.getString(R.string.cancel)).performClick()
+
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithText(activity.getString(R.string.logout_confirm)).isNotDisplayed() && !isMainScreen
+        }
+    }
+
+    @Test
+    fun loginButtonClick_showLogoutAlertDialog_checkButtonClick() = runTest {
+        composeTestRule.onNode(hasButton(R.string.logout)).performClick()
+
+        composeTestRule.onNodeWithText(activity.getString(R.string.logout_confirm)).assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(activity.getString(R.string.check)).performClick()
+
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithText(activity.getString(R.string.logout_confirm)).isNotDisplayed() && isMainScreen
+        }
+    }
+
+    private fun setContent() {
+        composeTestRule.setContent {
+            SettingScreen(
+                viewModel = SettingViewModel(tokenRepository, repoRepository, Dispatchers.IO, FakeBackOffWorkManager()),
+                onLogout = { isMainScreen = true }
+            )
+        }
+    }
+
+    private class FakeBackOffWorkManager: BackOffWorkManager {
+        override fun addWork(uniqueID: String, times: Int, initialDelay: Long, maxDelay: Long, factor: Double, work: suspend () -> Result<*>) { }
+
+        override fun clearWork() { }
+    }
+}

--- a/app/src/androidTest/java/com/prac/githubrepo/util/HasSemanticsPropertyKey.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/util/HasSemanticsPropertyKey.kt
@@ -2,6 +2,7 @@ package com.prac.githubrepo.util
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.test.SemanticsMatcher
 
 fun hasDrawable(@DrawableRes id: Int): SemanticsMatcher =
@@ -9,3 +10,6 @@ fun hasDrawable(@DrawableRes id: Int): SemanticsMatcher =
 
 fun hasButton(@StringRes id: Int): SemanticsMatcher =
     SemanticsMatcher.expectValue(ButtonID, id)
+
+fun hasIcon(id: ImageVector): SemanticsMatcher =
+    SemanticsMatcher.expectValue(IconID, id)

--- a/app/src/main/java/com/prac/githubrepo/NavGraph.kt
+++ b/app/src/main/java/com/prac/githubrepo/NavGraph.kt
@@ -52,7 +52,7 @@ fun NavGraph(
         ) { entry ->
             DetailScreen(
                 onLogout = { navActions.navigationToLogin() },
-                onBack = { navActions.navigationLoginToMain() },
+                onBack = { navController.popBackStack() },
                 userName = entry.arguments?.getString(USER_NAME_ARG),
                 repoName = entry.arguments?.getString(REPO_NAME_ARG)
             )

--- a/app/src/main/java/com/prac/githubrepo/main/MainScreen.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainScreen.kt
@@ -11,10 +11,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -42,6 +45,7 @@ import com.prac.githubrepo.constants.INVALID_TOKEN
 import com.prac.githubrepo.util.ErrorAlertDialog
 import com.prac.githubrepo.util.UserProfile
 import com.prac.githubrepo.util.drawableID
+import com.prac.githubrepo.util.iconID
 
 @Composable
 fun MainScreen(
@@ -121,8 +125,8 @@ fun MainContentHeader(
             }
         )
 
-        Image(
-            painter = painterResource(id = R.drawable.img_glide_profile),
+        Icon(
+            imageVector = Icons.Default.AccountCircle,
             contentDescription = null,
             modifier = Modifier
                 .padding(dimensionResource(id = R.dimen.padding_normal))
@@ -137,6 +141,7 @@ fun MainContentHeader(
                     indication = null,
                     onClick = onClickSetting
                 )
+                .semantics { iconID = Icons.Default.AccountCircle }
         )
 
         HorizontalDivider(

--- a/app/src/main/java/com/prac/githubrepo/main/setting/SettingPreview.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/setting/SettingPreview.kt
@@ -1,7 +1,9 @@
 package com.prac.githubrepo.main.setting
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.prac.githubrepo.R
 
 @Preview(showBackground = true)
 @Composable
@@ -33,7 +35,7 @@ fun SettingContentPreview() {
 fun SettingContentDialogPreview() {
     SettingContent(
         isLoading = false,
-        dialogMessage = "정말 로그아웃하시겠습니까?",
+        dialogMessage = stringResource(id = R.string.logout_confirm),
         onClickLogoutButton = { },
         onClickCheckButton = { },
         onDismissRequest = { }

--- a/app/src/main/java/com/prac/githubrepo/main/setting/SettingScreen.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/setting/SettingScreen.kt
@@ -40,7 +40,7 @@ fun SettingScreen(
         isLoading = uiState is SettingViewModel.UiState.Loading,
         dialogMessage = (uiState as? SettingViewModel.UiState.Dialog)?.message ?: "",
         onClickLogoutButton = {
-            viewModel.setUiState(SettingViewModel.UiState.Dialog(message = "정말 로그아웃하시겠습니까?"))
+            viewModel.setUiState(SettingViewModel.UiState.Dialog(message = activity.getString(R.string.logout_confirm)))
         },
         onClickCheckButton = { viewModel.logout() },
         onDismissRequest = { viewModel.setUiState(SettingViewModel.UiState.Idle) }

--- a/app/src/main/java/com/prac/githubrepo/util/SemanticsPropertyKey.kt
+++ b/app/src/main/java/com/prac/githubrepo/util/SemanticsPropertyKey.kt
@@ -1,5 +1,6 @@
 package com.prac.githubrepo.util
 
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 
@@ -8,3 +9,6 @@ var SemanticsPropertyReceiver.drawableID by DrawableID
 
 val ButtonID = SemanticsPropertyKey<Int>("buttonID")
 var SemanticsPropertyReceiver.buttonID by ButtonID
+
+val IconID = SemanticsPropertyKey<ImageVector>("iconID")
+var SemanticsPropertyReceiver.iconID by IconID

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="app_name">Github Repo</string>
 
+    <string name="logout_confirm">로그아웃 하시겠습니까?</string>
+
     <string name="check">확인</string>
     <string name="cancel">취소</string>
 

--- a/app/src/test/java/com/prac/githubrepo/main/setting/SettingViewModelTest.kt
+++ b/app/src/test/java/com/prac/githubrepo/main/setting/SettingViewModelTest.kt
@@ -1,0 +1,47 @@
+package com.prac.githubrepo.main.setting
+
+import com.prac.data.fake.FakeTokenRepository
+import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.util.FakeBackOffWorkManager
+import com.prac.githubrepo.util.StandardTestDispatcherRule
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class SettingViewModelTest {
+
+    @get:Rule
+    val standardTestDispatcherRule = StandardTestDispatcherRule()
+
+    private lateinit var tokenRepository: FakeTokenRepository
+    @Mock private lateinit var mockRepoRepository: RepoRepository
+    private lateinit var backOffWorkManager: FakeBackOffWorkManager
+
+    private lateinit var settingViewModel: SettingViewModel
+
+    @Before
+    fun setup() {
+        tokenRepository = FakeTokenRepository().apply { setInitialToken() }
+        backOffWorkManager = FakeBackOffWorkManager()
+
+        settingViewModel = SettingViewModel(tokenRepository, mockRepoRepository, standardTestDispatcherRule.testDispatcher, backOffWorkManager)
+    }
+
+    @Test
+    fun logout_success_eventIsSuccessAndTokenIsRemoved() = runTest {
+
+        settingViewModel.logout()
+
+        val event = settingViewModel.event.first()
+
+        assert(event is SettingViewModel.Event.Success)
+        assertFalse(tokenRepository.isLoggedIn())
+    }
+}

--- a/data/src/androidTest/java/com/prac/data/RepoRepositoryTest.kt
+++ b/data/src/androidTest/java/com/prac/data/RepoRepositoryTest.kt
@@ -30,6 +30,7 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -488,6 +489,21 @@ internal class RepoRepositoryTest {
 
         assertTrue(result.isFailure)
         assertTrue(result.exceptionOrNull() is CommonException.UnKnownError)
+    }
+
+    @Test
+    fun clearRepositories_clearRepositoriesAndRemoteKeys_roomIsEmpty() = runTest {
+        val repoDtoList = getRepoDtoListForPage(1, 10)
+        repositoryDatabase.repositoryDao().insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, false) })
+
+        repoRepository.clearRepositories()
+
+        repoDtoList.forEach {
+            val repository = repositoryDatabase.repositoryDao().getRepository(it.id).first()
+            assertNull(repository)
+            val remoteKey = repositoryDatabase.remoteKeyDao().remoteKey(it.id)
+            assertNull(remoteKey)
+        }
     }
 
     private fun getRepoDtoListForPage(page : Int, loadSize: Int) : List<RepoDto> =

--- a/data/src/test/java/com/prac/data/repository/TokenRepositoryTest.kt
+++ b/data/src/test/java/com/prac/data/repository/TokenRepositoryTest.kt
@@ -195,4 +195,18 @@ class TokenRepositoryTest {
 
         assertFalse(isLoggedIn)
     }
+
+    @Test
+    fun clearToken_clearTokenAndUserName_tokenAndUserNameIsEmpty() = runTest {
+        tokenLocalDataSource.setInitialToken()
+        userLocalDataSource.setInitialUserName()
+
+        tokenRepository.clearToken()
+
+        val token = tokenLocalDataSource.getToken()
+        val userName = userLocalDataSource.getUserName()
+        assertTrue(token.accessToken.isEmpty())
+        assertTrue(token.refreshToken.isEmpty())
+        assertTrue(userName.isEmpty())
+    }
 }


### PR DESCRIPTION
notion - https://www.notion.so/feat-SettingScreen-SettingViewModel-navGraph-12ea26591b61807b9d01d62bd3cc5a39?pvs=4

# AS-IS

- 현재 SettingScreen 테스트 코드가 존재하지 않다.
- 현재 SettingViewModel 테스트 코드가 존재하지 않다. SettingViewModel 을 작성하면서 추가된 clearToken, clearRepositories 메서드 테스트 코드가 존재하지 않다.
- navGraph 의 SettingScreen 테스트 코드가 존재하지 않다.

# TO-BE

- SettingScreen 테스트코드 작성 (MainScreen 에서 SettingScreen 으로 이동하기 위해 기존에는 img_glide_profile 을 사용했지만 icon 으로 변경) 및 icon 이 존재하는지 판단하기 위한 SemanticsProperty 추가
- SettingViewModel 테스트코드 작성
- SettingScreen navigation test code 작성
- clearToken, clearRepositories 메서드 테스트 코드 추가