### PR TITLE
refact: service and datastore fake 객체 로직 수정

### DIFF
--- a/local/src/test/java/com/prac/local/local/TokenLocalDataSourceTest.kt
+++ b/local/src/test/java/com/prac/local/local/TokenLocalDataSourceTest.kt
@@ -2,19 +2,29 @@ package com.prac.local.local
 
 import com.prac.local.TokenLocalDataSource
 import com.prac.local.datastore.token.TokenLocalDto
-import com.prac.shared_test.local.datastore.FakeTokenDataStoreManager
 import com.prac.local.impl.TokenLocalDataSourceImpl
+import com.prac.shared_test.local.datastore.FakeTokenDataStoreManager
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.time.Instant
+import java.time.ZoneId
 import java.time.ZonedDateTime
 
 internal class TokenLocalDataSourceTest {
 
     private lateinit var tokenDataStoreManager: FakeTokenDataStoreManager
     private lateinit var tokenLocalDataSource: TokenLocalDataSource
+
+    private val initialToken = TokenLocalDto(
+        accessToken = "accessToken",
+        refreshToken = "refreshToken",
+        expiresInSeconds = 3600,
+        refreshTokenExpiresInSeconds = 3600,
+        updatedAt = Instant.now().atZone(ZoneId.systemDefault())
+    )
 
     @After
     fun tearDown() = runTest {
@@ -34,7 +44,7 @@ internal class TokenLocalDataSourceTest {
 
     @Test
     fun getToken_dataStoreIsNotEmpty_notEmptyToken() = runTest {
-        tokenDataStoreManager = FakeTokenDataStoreManager().apply { setInitialToken() }
+        tokenDataStoreManager = FakeTokenDataStoreManager(initialToken)
         tokenLocalDataSource = TokenLocalDataSourceImpl(tokenDataStoreManager)
 
         val result = tokenLocalDataSource.getToken()
@@ -65,7 +75,7 @@ internal class TokenLocalDataSourceTest {
 
     @Test
     fun clearToken_updateEmptyToken_localAndCachedEmptyToken() = runTest {
-        tokenDataStoreManager = FakeTokenDataStoreManager().apply { setInitialToken() }
+        tokenDataStoreManager = FakeTokenDataStoreManager(initialToken)
         tokenLocalDataSource = TokenLocalDataSourceImpl(tokenDataStoreManager)
 
         tokenLocalDataSource.clearToken()

--- a/local/src/test/java/com/prac/local/local/UserLocalDataSourceTest.kt
+++ b/local/src/test/java/com/prac/local/local/UserLocalDataSourceTest.kt
@@ -1,8 +1,8 @@
 package com.prac.local.local
 
 import com.prac.local.UserLocalDataSource
-import com.prac.shared_test.local.datastore.FakeUserDataStoreManager
 import com.prac.local.impl.UserLocalDataSourceImpl
+import com.prac.shared_test.local.datastore.FakeUserDataStoreManager
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -12,6 +12,8 @@ class UserLocalDataSourceTest {
 
     private lateinit var userDataStoreManager: FakeUserDataStoreManager
     private lateinit var userLocalDataSource: UserLocalDataSource
+
+    private val initialUserName = "test"
 
     @Test
     fun getUserName_dataStoreIsEmpty_emptyUserName() = runTest {
@@ -25,7 +27,7 @@ class UserLocalDataSourceTest {
 
     @Test
     fun getUserName_dataStoreIsNotEmpty_notEmptyUserName() = runTest {
-        userDataStoreManager = FakeUserDataStoreManager().apply { setInitialUserName() }
+        userDataStoreManager = FakeUserDataStoreManager(initialUserName)
         userLocalDataSource = UserLocalDataSourceImpl(userDataStoreManager)
 
         val result = userLocalDataSource.getUserName()
@@ -49,7 +51,7 @@ class UserLocalDataSourceTest {
 
     @Test
     fun clearUserName_updateEmptyUserName_cacheAndLocalEmptyUserName() = runTest {
-        userDataStoreManager = FakeUserDataStoreManager().apply { setInitialUserName() }
+        userDataStoreManager = FakeUserDataStoreManager(initialUserName)
         userLocalDataSource = UserLocalDataSourceImpl(userDataStoreManager)
 
         userLocalDataSource.clearUserName()

--- a/network/src/test/java/com/prac/network/AuthApiDataSourceTest.kt
+++ b/network/src/test/java/com/prac/network/AuthApiDataSourceTest.kt
@@ -1,10 +1,11 @@
 package com.prac.network
 
 import com.prac.network.dto.TokenDto
-import com.prac.shared_test.network.service.FakeGitHubAuthService
 import com.prac.network.impl.AuthApiDataSourceImpl
+import com.prac.shared_test.network.service.FakeGitHubAuthService
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -13,49 +14,41 @@ internal class AuthApiDataSourceTest {
     private lateinit var gitHubAuthService: FakeGitHubAuthService
     private lateinit var authApiDataSource: AuthApiDataSource
 
+    private val token = TokenDto(
+        accessToken = "accessToken",
+        expiresIn = 3600,
+        refreshToken= "refreshToken",
+        refreshTokenExpiresIn = 18000,
+        scope = "",
+        tokenType = "Bearer"
+    )
     private val code = "code"
 
     @Before
     fun setup() {
-        gitHubAuthService = FakeGitHubAuthService()
+        gitHubAuthService = FakeGitHubAuthService(token)
         authApiDataSource = AuthApiDataSourceImpl(gitHubAuthService)
     }
 
     @Test
     fun authorizeOAuth_whenCalled_token() = runTest {
-        val expectedToken = TokenDto(
-            accessToken = "accessToken",
-            expiresIn = 3600,
-            refreshToken= "refreshToken",
-            refreshTokenExpiresIn = 18000,
-            scope = "",
-            tokenType = "Bearer"
-        )
 
         val result = authApiDataSource.authorizeOAuth(code)
 
-        assertEquals(result.accessToken, expectedToken.accessToken)
-        assertEquals(result.refreshToken, expectedToken.refreshToken)
-        assertEquals(result.expiresIn, expectedToken.expiresIn)
-        assertEquals(result.refreshTokenExpiresIn, expectedToken.refreshTokenExpiresIn)
+        assertEquals(result.accessToken, token.accessToken)
+        assertEquals(result.refreshToken, token.refreshToken)
+        assertEquals(result.expiresIn, token.expiresIn)
+        assertEquals(result.refreshTokenExpiresIn, token.refreshTokenExpiresIn)
     }
 
     @Test
     fun refreshAccessToken_whenCalled_refreshToken() = runTest {
-        val expectedToken = TokenDto(
-            accessToken = "refreshAccessToken",
-            expiresIn = 3600,
-            refreshToken= "refreshRefreshToken",
-            refreshTokenExpiresIn = 18000,
-            scope = "",
-            tokenType = "Bearer"
-        )
 
         val result = authApiDataSource.refreshAccessToken(code)
 
-        assertEquals(result.accessToken, expectedToken.accessToken)
-        assertEquals(result.refreshToken, expectedToken.refreshToken)
-        assertEquals(result.expiresIn, expectedToken.expiresIn)
-        assertEquals(result.refreshTokenExpiresIn, expectedToken.refreshTokenExpiresIn)
+        assertNotEquals(result.accessToken, token.accessToken)
+        assertNotEquals(result.refreshToken, token.refreshToken)
+        assertNotEquals(result.expiresIn, token.expiresIn)
+        assertNotEquals(result.refreshTokenExpiresIn, token.refreshTokenExpiresIn)
     }
 }

--- a/network/src/test/java/com/prac/network/RepoApiDataSourceTest.kt
+++ b/network/src/test/java/com/prac/network/RepoApiDataSourceTest.kt
@@ -2,8 +2,8 @@ package com.prac.network
 
 import com.prac.network.dto.OwnerDto
 import com.prac.network.dto.RepoDto
-import com.prac.shared_test.network.service.FakeGitHubService
 import com.prac.network.impl.RepoApiDataSourceImpl
+import com.prac.shared_test.network.service.FakeGitHubService
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -14,7 +14,7 @@ class RepoApiDataSourceTest {
     private lateinit var gitHubService: FakeGitHubService
     private lateinit var repoApiDatasource: RepoApiDataSource
 
-    private val expectedRepoList = listOf(
+    private val repoList = listOf(
         RepoDto(0, "test1", OwnerDto("test1", "test1"), 0, "master", "test1"),
         RepoDto(1, "test2", OwnerDto("test2", "test2"), 0, "master", "test1"),
         RepoDto(2, "test3", OwnerDto("test3", "test3"), 0, "master", "test1"),
@@ -23,7 +23,7 @@ class RepoApiDataSourceTest {
 
     @Before
     fun setUp() {
-        gitHubService = FakeGitHubService()
+        gitHubService = FakeGitHubService(repoList)
         repoApiDatasource = RepoApiDataSourceImpl(gitHubService)
     }
 
@@ -35,20 +35,20 @@ class RepoApiDataSourceTest {
 
         val result = repoApiDatasource.getRepositories(userName, perPage, page)
 
-        assertEquals(result.size, expectedRepoList.size)
+        assertEquals(result.size, repoList.size)
         result.indices.forEach {
-            assertEquals(result[it].id, expectedRepoList[it].id)
-            assertEquals(result[it].name, expectedRepoList[it].name)
-            assertEquals(result[it].owner.login, expectedRepoList[it].owner.login)
-            assertEquals(result[it].owner.avatarUrl, expectedRepoList[it].owner.avatarUrl)
-            assertEquals(result[it].stargazersCount, expectedRepoList[it].stargazersCount)
-            assertEquals(result[it].updatedAt, expectedRepoList[it].updatedAt)
+            assertEquals(result[it].id, repoList[it].id)
+            assertEquals(result[it].name, repoList[it].name)
+            assertEquals(result[it].owner.login, repoList[it].owner.login)
+            assertEquals(result[it].owner.avatarUrl, repoList[it].owner.avatarUrl)
+            assertEquals(result[it].stargazersCount, repoList[it].stargazersCount)
+            assertEquals(result[it].updatedAt, repoList[it].updatedAt)
         }
     }
 
     @Test
     fun getRepository_whenCalled_repoDetailDto() = runTest {
-        val expectedRepo = expectedRepoList[0]
+        val expectedRepo = repoList[0]
 
         val result = repoApiDatasource.getRepository(expectedRepo.owner.login, expectedRepo.name)
 

--- a/network/src/test/java/com/prac/network/UserApiDataSourceTest.kt
+++ b/network/src/test/java/com/prac/network/UserApiDataSourceTest.kt
@@ -14,24 +14,25 @@ class UserApiDataSourceTest {
     private lateinit var gitHubUserService: FakeGitHubUserService
     private lateinit var repoStarApiDataSource: UserApiDataSource
 
+    private val user = UserDto(
+        user = OwnerDto(
+            login = "test",
+            avatarUrl = "test"
+        )
+    )
+
     @Before
     fun setUp() {
-        gitHubUserService = FakeGitHubUserService()
+        gitHubUserService = FakeGitHubUserService(user)
         repoStarApiDataSource = UserApiDataSourceImpl(gitHubUserService)
     }
 
     @Test
     fun getUser_whenCalled_user() = runTest {
         val accessToken = "test"
-        val expectedUser = UserDto(
-            user = OwnerDto(
-                login = "test",
-                avatarUrl = "test"
-            )
-        )
 
         val result = repoStarApiDataSource.getUserName(accessToken)
 
-        assertEquals(result, expectedUser.user.login)
+        assertEquals(result, user.user.login)
     }
 }

--- a/shared-test/src/main/java/com/prac/shared_test/local/datastore/FakeTokenDataStoreManager.kt
+++ b/shared-test/src/main/java/com/prac/shared_test/local/datastore/FakeTokenDataStoreManager.kt
@@ -5,8 +5,7 @@ import com.prac.local.datastore.token.TokenLocalDto
 import java.time.Instant
 import java.time.ZoneId
 
-class FakeTokenDataStoreManager : TokenDataStoreManager {
-
+class FakeTokenDataStoreManager(
     private var token: TokenLocalDto = TokenLocalDto(
         accessToken = "",
         refreshToken = "",
@@ -14,16 +13,7 @@ class FakeTokenDataStoreManager : TokenDataStoreManager {
         refreshTokenExpiresInSeconds = 0,
         updatedAt = Instant.ofEpochMilli(0).atZone(ZoneId.systemDefault())
     )
-
-    fun setInitialToken() {
-        token = token.copy(
-            accessToken = "accessToken",
-            refreshToken = "refreshToken",
-            expiresInSeconds = 3600,
-            refreshTokenExpiresInSeconds = 3600,
-            updatedAt = Instant.now().atZone(ZoneId.systemDefault())
-        )
-    }
+) : TokenDataStoreManager {
 
     override suspend fun setToken(token: TokenLocalDto) {
         this.token = token

--- a/shared-test/src/main/java/com/prac/shared_test/local/datastore/FakeUserDataStoreManager.kt
+++ b/shared-test/src/main/java/com/prac/shared_test/local/datastore/FakeUserDataStoreManager.kt
@@ -2,13 +2,9 @@ package com.prac.shared_test.local.datastore
 
 import com.prac.local.datastore.user.UserDataStoreManager
 
-class FakeUserDataStoreManager : UserDataStoreManager {
-
-    private var userName = ""
-
-    fun setInitialUserName() {
-        userName = "test"
-    }
+class FakeUserDataStoreManager(
+    private var userName: String = ""
+) : UserDataStoreManager {
 
     override suspend fun setUserName(userName: String) {
         this.userName = userName

--- a/shared-test/src/main/java/com/prac/shared_test/network/service/FakeGitHubAuthService.kt
+++ b/shared-test/src/main/java/com/prac/shared_test/network/service/FakeGitHubAuthService.kt
@@ -3,16 +3,12 @@ package com.prac.shared_test.network.service
 import com.prac.network.dto.TokenDto
 import com.prac.network.service.GitHubAuthService
 
-class FakeGitHubAuthService: GitHubAuthService {
+class FakeGitHubAuthService(
+    private var token: TokenDto
+): GitHubAuthService {
+
     override suspend fun authorizeOAuth(accept: String, clientID: String, clientSecret: String, code: String): TokenDto {
-        return TokenDto(
-            accessToken = "accessToken",
-            expiresIn = 3600,
-            refreshToken= "refreshToken",
-            refreshTokenExpiresIn = 18000,
-            scope = "",
-            tokenType = "Bearer"
-        )
+        return token
     }
 
     override suspend fun refreshAccessToken(accept: String, clientID: String, clientSecret: String, grantType: String, refreshToken: String): TokenDto {

--- a/shared-test/src/main/java/com/prac/shared_test/network/service/FakeGitHubService.kt
+++ b/shared-test/src/main/java/com/prac/shared_test/network/service/FakeGitHubService.kt
@@ -1,18 +1,12 @@
 package com.prac.shared_test.network.service
 
-import com.prac.network.dto.OwnerDto
 import com.prac.network.dto.RepoDetailDto
 import com.prac.network.dto.RepoDto
 import com.prac.network.service.GitHubService
 
-class FakeGitHubService: GitHubService {
-
-    private val repoList = listOf(
-        RepoDto(0, "test1", OwnerDto("test1", "test1"), 0, "master", "test1"),
-        RepoDto(1, "test2", OwnerDto("test2", "test2"), 0, "master", "test1"),
-        RepoDto(2, "test3", OwnerDto("test3", "test3"), 0, "master", "test1"),
-        RepoDto(3, "test4", OwnerDto("test4", "test4"), 0, "master", "test1"),
-    )
+class FakeGitHubService(
+    private val repoList: List<RepoDto>
+): GitHubService {
 
     override suspend fun getRepos(userName: String, perPage: Int, page: Int): List<RepoDto> {
         return repoList

--- a/shared-test/src/main/java/com/prac/shared_test/network/service/FakeGitHubUserService.kt
+++ b/shared-test/src/main/java/com/prac/shared_test/network/service/FakeGitHubUserService.kt
@@ -5,13 +5,10 @@ import com.prac.network.dto.OwnerDto
 import com.prac.network.dto.UserDto
 import com.prac.network.service.GitHubUserService
 
-class FakeGitHubUserService : GitHubUserService {
+class FakeGitHubUserService(
+    private val user: UserDto
+) : GitHubUserService {
     override suspend fun getUserInformation(clientId: String, accept: String, authorization: String, accessToken: AccessTokenRequest): UserDto {
-        return UserDto(
-            user = OwnerDto(
-                login = "test",
-                avatarUrl = "test"
-            )
-        )
+        return user
     }
 }


### PR DESCRIPTION
notion - https://www.notion.so/refact-service-and-datastore-fake-133a26591b618096b008efe0dc2aff9d?pvs=4

# TO-BE

- service 및 datastore fake 객체들의 로직 수정 및 이를 사용하는 Test 로직 수정