### PR TITLE
feat: RepoRepository 구현체 의존성 주입을 위한 local data source 생성

### DIFF
--- a/data/src/main/java/com/prac/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/prac/data/di/RepositoryModule.kt
@@ -4,6 +4,8 @@ import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.TokenRepository
 import com.prac.data.repository.impl.RepoRepositoryImpl
 import com.prac.data.repository.impl.TokenRepositoryImpl
+import com.prac.local.RemoteKeyLocalDataSource
+import com.prac.local.RepositoryLocalDataSource
 import com.prac.local.TokenLocalDataSource
 import com.prac.local.UserLocalDataSource
 import com.prac.local.room.database.RepositoryDatabase
@@ -35,8 +37,9 @@ class RepositoryModule {
     fun provideRepoRepository(
         repoApiDataSource: RepoApiDataSource,
         repoStarApiDataSource: RepoStarApiDataSource,
-        repositoryDatabase: RepositoryDatabase,
+        repositoryLocalDataSource: RepositoryLocalDataSource,
+        remoteKeyLocalDataSource: RemoteKeyLocalDataSource,
         userLocalDataSource: UserLocalDataSource
     ): RepoRepository =
-        RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource, repositoryDatabase, userLocalDataSource)
+        RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource, repositoryLocalDataSource, remoteKeyLocalDataSource, userLocalDataSource)
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -14,6 +14,8 @@ import com.prac.data.entity.RepoEntity
 import com.prac.data.exception.CommonException
 import com.prac.data.exception.RepositoryException
 import com.prac.data.repository.RepoRepository
+import com.prac.local.RemoteKeyLocalDataSource
+import com.prac.local.RepositoryLocalDataSource
 import com.prac.local.UserLocalDataSource
 import com.prac.local.room.database.RepositoryDatabase
 import com.prac.local.room.entity.Owner
@@ -30,7 +32,8 @@ import javax.inject.Inject
 internal class RepoRepositoryImpl @Inject constructor(
     private val repoApiDataSource: RepoApiDataSource,
     private val repoStarApiDataSource: RepoStarApiDataSource,
-    private val repositoryDatabase: RepositoryDatabase,
+    private val repositoryLocalDataSource: RepositoryLocalDataSource,
+    private val remoteKeyLocalDataSource: RemoteKeyLocalDataSource,
     private val userLocalDataSource: UserLocalDataSource
 ) : RepoRepository() {
 
@@ -46,7 +49,7 @@ internal class RepoRepositoryImpl @Inject constructor(
                 // false -> true
             ),
             remoteMediator = this,
-            pagingSourceFactory = { repositoryDatabase.repositoryDao().getRepositories() }
+            pagingSourceFactory = { repositoryLocalDataSource.getRepositories() }
         ).flow
             .map { pagingData ->
                 pagingData.map { repository ->
@@ -60,7 +63,7 @@ internal class RepoRepositoryImpl @Inject constructor(
             val model = repoApiDataSource.getRepository(userName, repoName)
 
             // 디테일 화면에 들어오는 동안 Star Count 가 변경될 수 있기 때문에 Star Count update
-            repositoryDatabase.repositoryDao().updateStarCount(model.id, model.stargazersCount)
+            repositoryLocalDataSource.updateStarCount(model.id, model.stargazersCount)
 
             Result.success(
                 RepoDetailEntity(
@@ -73,12 +76,12 @@ internal class RepoRepositoryImpl @Inject constructor(
     }
 
     override suspend fun clearRepositories() {
-        repositoryDatabase.repositoryDao().clearRepositories()
-        repositoryDatabase.remoteKeyDao().clearRemoteKeys()
+        repositoryLocalDataSource.clearRepositories()
+        remoteKeyLocalDataSource.clearRemoteKeys()
     }
 
     override suspend fun getStarStateAndStarCount(id: Int): Flow<Pair<Boolean?, Int?>> {
-        return repositoryDatabase.repositoryDao().getRepository(id).map { Pair(it?.isStarred, it?.stargazersCount) }
+        return repositoryLocalDataSource.getRepository(id).map { Pair(it?.isStarred, it?.stargazersCount) }
     }
 
     override suspend fun isStarred(id: Int, repoName: String) {
@@ -87,9 +90,9 @@ internal class RepoRepositoryImpl @Inject constructor(
 
             repoStarApiDataSource.isStarred(userName, repoName)
 
-            repositoryDatabase.repositoryDao().updateStarState(id, true)
+            repositoryLocalDataSource.updateStarState(id, true)
         } catch (e: Exception) {
-            repositoryDatabase.repositoryDao().updateStarState(id, false)
+            repositoryLocalDataSource.updateStarState(id, false)
         }
     }
 
@@ -114,11 +117,11 @@ internal class RepoRepositoryImpl @Inject constructor(
     }
 
     override suspend fun starLocalRepository(id: Int, updatedStarCount: Int) {
-        repositoryDatabase.repositoryDao().updateStarStateAndStarCount(id, true, updatedStarCount)
+        repositoryLocalDataSource.updateStarStateAndStarCount(id, true, updatedStarCount)
     }
 
     override suspend fun unStarLocalRepository(id: Int, updatedStarCount: Int) {
-        repositoryDatabase.repositoryDao().updateStarStateAndStarCount(id, false, updatedStarCount)
+        repositoryLocalDataSource.updateStarStateAndStarCount(id, false, updatedStarCount)
     }
 
     @OptIn(ExperimentalPagingApi::class)
@@ -146,22 +149,21 @@ internal class RepoRepositoryImpl @Inject constructor(
             val userName = userLocalDataSource.getUserName()
             val response = repoApiDataSource.getRepositories(userName, PAGE_SIZE, page)
 
-            repositoryDatabase.withTransaction {
-                if (loadType == LoadType.REFRESH) {
-                    repositoryDatabase.remoteKeyDao().clearRemoteKeys()
-                    repositoryDatabase.repositoryDao().clearRepositories()
-                }
-                val prevKey = if (page == STARTING_PAGE_INDEX) null else page - 1
-                val nextKey = if (response.size < 10) null else page + 1
-                val keys = response.map {
-                    RemoteKey(it.id, prevKey, nextKey)
-                }
-                val repositories = response.map {
-                    Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, null)
-                }
-                repositoryDatabase.remoteKeyDao().insertRemoteKeys(keys)
-                repositoryDatabase.repositoryDao().insertRepositories(repositories)
+            if (loadType == LoadType.REFRESH) {
+                remoteKeyLocalDataSource.clearRemoteKeys()
+                repositoryLocalDataSource.clearRepositories()
             }
+            val prevKey = if (page == STARTING_PAGE_INDEX) null else page - 1
+            val nextKey = if (response.size < 10) null else page + 1
+            val keys = response.map {
+                RemoteKey(it.id, prevKey, nextKey)
+            }
+            val repositories = response.map {
+                Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, null)
+            }
+            remoteKeyLocalDataSource.insertRemoteKeys(keys)
+            repositoryLocalDataSource.insertRepositories(repositories)
+
             return MediatorResult.Success(endOfPaginationReached = response.size < 10)
         } catch (exception: Exception) {
             return MediatorResult.Error(exception)
@@ -171,7 +173,7 @@ internal class RepoRepositoryImpl @Inject constructor(
     private suspend fun getRemoteKeyClosestToCurrentPosition(state: PagingState<Int, Repository>): RemoteKey? {
         return state.anchorPosition?.let { position ->
             state.closestItemToPosition(position)?.id?.let { repoId ->
-                repositoryDatabase.remoteKeyDao().remoteKey(repoId)
+                remoteKeyLocalDataSource.remoteKey(repoId)
             }
         }
     }
@@ -179,14 +181,14 @@ internal class RepoRepositoryImpl @Inject constructor(
     private suspend fun getRemoteKeyForFirstItem(state: PagingState<Int, Repository>): RemoteKey? {
         return state.pages.firstOrNull { it.data.isNotEmpty() }?.data?.firstOrNull()
             ?.let { repo ->
-                repositoryDatabase.remoteKeyDao().remoteKey(repo.id)
+                remoteKeyLocalDataSource.remoteKey(repo.id)
             }
     }
 
     private suspend fun getRemoteKeyForLastItem(state: PagingState<Int, Repository>): RemoteKey? {
         return state.pages.lastOrNull { it.data.isNotEmpty() }?.data?.lastOrNull()
             ?.let { repo ->
-                repositoryDatabase.remoteKeyDao().remoteKey(repo.id)
+                remoteKeyLocalDataSource.remoteKey(repo.id)
             }
     }
 

--- a/data/src/test/java/com/prac/data/repository/RepoRepositoryTest.kt
+++ b/data/src/test/java/com/prac/data/repository/RepoRepositoryTest.kt
@@ -1,4 +1,4 @@
-package com.prac.data
+package com.prac.data.repository
 
 import androidx.paging.ExperimentalPagingApi
 import androidx.paging.LoadType
@@ -6,49 +6,41 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import androidx.paging.RemoteMediator
-import androidx.room.Room
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import com.prac.data.exception.CommonException
 import com.prac.data.exception.RepositoryException
-import com.prac.data.repository.RepoRepository
 import com.prac.data.repository.impl.RepoRepositoryImpl
+import com.prac.local.RemoteKeyLocalDataSource
+import com.prac.local.RepositoryLocalDataSource
 import com.prac.local.UserLocalDataSource
-import com.prac.shared_test.local.source.FakeUserLocalDataSource
-import com.prac.local.room.dao.RemoteKeyDao
-import com.prac.local.room.dao.RepositoryDao
-import com.prac.local.room.database.RepositoryDatabase
 import com.prac.local.room.entity.Owner
 import com.prac.local.room.entity.Repository
 import com.prac.network.dto.OwnerDto
 import com.prac.network.dto.RepoDto
+import com.prac.shared_test.local.source.FakeRemoteKeyLocalDataSource
+import com.prac.shared_test.local.source.FakeRepositoryLocalDataSource
+import com.prac.shared_test.local.source.FakeUserLocalDataSource
 import com.prac.shared_test.network.FakeRepoApiDataSource
 import com.prac.shared_test.network.FakeRepoStarApiDataSource
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import okhttp3.ResponseBody.Companion.toResponseBody
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import retrofit2.HttpException
 import retrofit2.Response
 import java.io.IOException
 
-@RunWith(AndroidJUnit4::class)
 internal class RepoRepositoryTest {
 
     private lateinit var repoApiDataSource: FakeRepoApiDataSource
     private lateinit var repoStarApiDataSource: FakeRepoStarApiDataSource
     private lateinit var userLocalDataSource: UserLocalDataSource
-
-    private lateinit var repositoryDatabase: RepositoryDatabase
-    private lateinit var remoteKeyDao: RemoteKeyDao
-    private lateinit var repositoryDao: RepositoryDao
+    private lateinit var repositoryLocalDataSource: RepositoryLocalDataSource
+    private lateinit var remoteKeyLocalDataSource: RemoteKeyLocalDataSource
 
     private lateinit var repoRepository: RepoRepository
 
@@ -56,25 +48,13 @@ internal class RepoRepositoryTest {
 
     @Before
     fun setUp() {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
         repoApiDataSource = FakeRepoApiDataSource()
         repoStarApiDataSource = FakeRepoStarApiDataSource()
         userLocalDataSource = FakeUserLocalDataSource()
+        repositoryLocalDataSource = FakeRepositoryLocalDataSource()
+        remoteKeyLocalDataSource = FakeRemoteKeyLocalDataSource()
 
-        repositoryDatabase = Room
-            .inMemoryDatabaseBuilder(context, RepositoryDatabase::class.java)
-            .build()
-        remoteKeyDao = repositoryDatabase.remoteKeyDao()
-        repositoryDao = repositoryDatabase.repositoryDao()
-
-        repoRepository = RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource, repositoryDatabase, userLocalDataSource)
-    }
-
-    @After
-    fun tearDown() = runTest {
-        repositoryDatabase.repositoryDao().clearRepositories()
-        repositoryDatabase.remoteKeyDao().clearRemoteKeys()
-        repositoryDatabase.close()
+        repoRepository = RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource, repositoryLocalDataSource, remoteKeyLocalDataSource, userLocalDataSource)
     }
 
     @OptIn(ExperimentalPagingApi::class)
@@ -95,7 +75,7 @@ internal class RepoRepositoryTest {
 
         val result = repoRepository.load(LoadType.REFRESH, pagingState)
 
-        val roomRepositories = (repositoryDao.getRepositories().load(
+        val roomRepositories = (repositoryLocalDataSource.getRepositories().load(
             PagingSource.LoadParams.Refresh(
                 key = null,
                 loadSize = pageLoadSize,
@@ -105,7 +85,7 @@ internal class RepoRepositoryTest {
         assertEquals(roomRepositories?.size, repoDtoList.size)
         repoDtoList.indices.forEach {
             assertEquals(roomRepositories?.get(it)?.id, repoDtoList[it].id)
-            val remoteKey = remoteKeyDao.remoteKey(repoDtoList[it].id)
+            val remoteKey = remoteKeyLocalDataSource.remoteKey(repoDtoList[it].id)
             assertEquals(remoteKey?.repoId, repoDtoList[it].id)
             assertEquals(remoteKey?.prevKey, prevKey)
             assertEquals(remoteKey?.nextKey, nextKey)
@@ -132,7 +112,7 @@ internal class RepoRepositoryTest {
 
         val result = repoRepository.load(LoadType.REFRESH, pagingState)
 
-        val roomRepositories = (repositoryDao.getRepositories().load(
+        val roomRepositories = (repositoryLocalDataSource.getRepositories().load(
             PagingSource.LoadParams.Refresh(
                 key = null,
                 loadSize = pageLoadSize,
@@ -142,7 +122,7 @@ internal class RepoRepositoryTest {
         assertEquals(roomRepositories?.size, repoDtoList.size)
         repoDtoList.indices.forEach {
             assertEquals(roomRepositories?.get(it)?.id, repoDtoList[it].id)
-            val remoteKey = remoteKeyDao.remoteKey(repoDtoList[it].id)
+            val remoteKey = remoteKeyLocalDataSource.remoteKey(repoDtoList[it].id)
             assertEquals(remoteKey?.repoId, repoDtoList[it].id)
             assertEquals(remoteKey?.prevKey, prevKey)
             assertEquals(remoteKey?.nextKey, nextKey)
@@ -164,7 +144,7 @@ internal class RepoRepositoryTest {
                     data = totalRepoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, null) },
                     prevKey = 0, // data 의 id 를 통해 remoteKey 를 가져오기 때문에 0 으로 구현
                     nextKey = 0 // data 의 id 를 통해 remoteKey 를 가져오기 때문에 0 으로 구현
-                    )
+                )
                 ),
                 anchorPosition = null,
                 config = PagingConfig(pageSize = pageLoadSize, enablePlaceholders = false),
@@ -179,13 +159,13 @@ internal class RepoRepositoryTest {
             val loadParams =
                 if (page == 0)
                     PagingSource.LoadParams.Refresh(
-                        key = page,
+                        key = 1,
                         loadSize = pageLoadSize,
                         placeholdersEnabled = false
                     )
                 else
                     PagingSource.LoadParams.Append(
-                        key = pageLoadSize * page,
+                        key = page + 1,
                         loadSize = pageLoadSize,
                         placeholdersEnabled = false
                     )
@@ -195,11 +175,11 @@ internal class RepoRepositoryTest {
                 pagingState
             )
 
-            val roomRepositories = (repositoryDao.getRepositories().load(loadParams) as? PagingSource.LoadResult.Page)
+            val roomRepositories = (repositoryLocalDataSource.getRepositories().load(loadParams) as? PagingSource.LoadResult.Page)
             assertEquals(roomRepositories?.data?.size, pageLoadSize)
             roomRepositories?.data?.indices?.forEach {
                 assertEquals(roomRepositories.data[it].id, repoDtoList[it].id)
-                val remoteKey = remoteKeyDao.remoteKey(roomRepositories.data[it].id)
+                val remoteKey = remoteKeyLocalDataSource.remoteKey(roomRepositories.data[it].id)
                 assertEquals(remoteKey?.repoId, repoDtoList[it].id)
                 assertEquals(remoteKey?.prevKey, prevKey)
                 assertEquals(remoteKey?.nextKey, nextKey)
@@ -221,7 +201,7 @@ internal class RepoRepositoryTest {
 
         val result = repoRepository.load(LoadType.REFRESH, pagingState)
 
-        val roomRepositoryList = (repositoryDao.getRepositories().load(
+        val roomRepositoryList = (repositoryLocalDataSource.getRepositories().load(
             PagingSource.LoadParams.Refresh(
                 key = null,
                 loadSize = pageLoadSize,
@@ -239,11 +219,11 @@ internal class RepoRepositoryTest {
         val index = 0
         val repoDtoList = getRepoDtoListForPage(page, loadSize)
         val repoDto = repoDtoList[index]
-        repositoryDatabase.repositoryDao().insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, null) })
+        repositoryLocalDataSource.insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, null) })
 
         repoRepository.isStarred(repoDto.id, repoDto.name)
 
-        val roomRepository = repositoryDao.getRepository(repoDto.id).first()
+        val roomRepository = repositoryLocalDataSource.getRepository(repoDto.id).first()
         assertEquals(roomRepository?.isStarred, true)
     }
 
@@ -254,12 +234,12 @@ internal class RepoRepositoryTest {
         val index = 0
         val repoDtoList = getRepoDtoListForPage(page, loadSize)
         val repoDto = repoDtoList[index]
-        repositoryDatabase.repositoryDao().insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, null) })
+        repositoryLocalDataSource.insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, null) })
         repoStarApiDataSource.setThrowable(Exception()) // 사용자가 repository 를 star 하고 있지 않을 경우 응답이 304 이기 때문에 예외를 발생시켜서 테스트 진행
 
         repoRepository.isStarred(repoDto.id, repoDto.name)
 
-        val roomRepository = repositoryDao.getRepository(repoDto.id).first()
+        val roomRepository = repositoryLocalDataSource.getRepository(repoDto.id).first()
         assertEquals(roomRepository?.isStarred, false)
     }
 
@@ -386,11 +366,11 @@ internal class RepoRepositoryTest {
         val index = 0
         val repoDtoList = getRepoDtoListForPage(page, loadSize)
         val repoDto = repoDtoList[index]
-        repositoryDatabase.repositoryDao().insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, false) })
+        repositoryLocalDataSource.insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, false) })
 
         repoRepository.starLocalRepository(repoDto.id, repoDto.stargazersCount + 1)
 
-        val roomRepository = repositoryDao.getRepository(repoDto.id).first()
+        val roomRepository = repositoryLocalDataSource.getRepository(repoDto.id).first()
         assertEquals(roomRepository?.isStarred, true)
         assertEquals(roomRepository?.stargazersCount, repoDto.stargazersCount + 1)
     }
@@ -402,11 +382,11 @@ internal class RepoRepositoryTest {
         val index = 0
         val repoDtoList = getRepoDtoListForPage(page, loadSize)
         val repoDto = repoDtoList[index]
-        repositoryDatabase.repositoryDao().insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount + 1, it.updatedAt, it.defaultBranch, true) })
+        repositoryLocalDataSource.insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount + 1, it.updatedAt, it.defaultBranch, true) })
 
         repoRepository.unStarLocalRepository(repoDto.id, repoDto.stargazersCount)
 
-        val roomRepository = repositoryDao.getRepository(repoDto.id).first()
+        val roomRepository = repositoryLocalDataSource.getRepository(repoDto.id).first()
         assertEquals(roomRepository?.isStarred, false)
         assertEquals(roomRepository?.stargazersCount, repoDto.stargazersCount)
     }
@@ -417,11 +397,11 @@ internal class RepoRepositoryTest {
         val index = 0
         val repoDto = repoDtoList[index]
         repoApiDataSource.setRepoDtoList(repoDtoList)
-        repositoryDatabase.repositoryDao().insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, false) })
+        repositoryLocalDataSource.insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, false) })
 
         val result = repoRepository.getRepository(repoDto.owner.login, repoDto.name)
 
-        val repository = repositoryDatabase.repositoryDao().getRepository(repoDto.id).first()
+        val repository = repositoryLocalDataSource.getRepository(repoDto.id).first()
         assertEquals(repository?.stargazersCount, 0)
         assertTrue(result.isSuccess)
     }
@@ -432,13 +412,13 @@ internal class RepoRepositoryTest {
         val index = 0
         val repoDto = repoDtoList[index]
         val starCount = 10
-        repositoryDatabase.repositoryDao().insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, false) })
+        repositoryLocalDataSource.insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, false) })
         repoApiDataSource.setRepoDtoList(repoDtoList)
         repoApiDataSource.setStarCount(starCount)
 
         val result = repoRepository.getRepository(repoDto.owner.login, repoDto.name)
 
-        val repository = repositoryDatabase.repositoryDao().getRepository(repoDto.id).first()
+        val repository = repositoryLocalDataSource.getRepository(repoDto.id).first()
         assertEquals(repository?.stargazersCount, starCount)
         assertTrue(result.isSuccess)
     }
@@ -494,14 +474,14 @@ internal class RepoRepositoryTest {
     @Test
     fun clearRepositories_clearRepositoriesAndRemoteKeys_roomIsEmpty() = runTest {
         val repoDtoList = getRepoDtoListForPage(1, 10)
-        repositoryDatabase.repositoryDao().insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, false) })
+        repositoryLocalDataSource.insertRepositories(repoDtoList.map { Repository(it.id, it.name, Owner(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt, it.defaultBranch, false) })
 
         repoRepository.clearRepositories()
 
         repoDtoList.forEach {
-            val repository = repositoryDatabase.repositoryDao().getRepository(it.id).first()
+            val repository = repositoryLocalDataSource.getRepository(it.id).first()
             assertNull(repository)
-            val remoteKey = repositoryDatabase.remoteKeyDao().remoteKey(it.id)
+            val remoteKey = remoteKeyLocalDataSource.remoteKey(it.id)
             assertNull(remoteKey)
         }
     }

--- a/local/src/main/java/com/prac/local/RemoteKeyLocalDataSource.kt
+++ b/local/src/main/java/com/prac/local/RemoteKeyLocalDataSource.kt
@@ -1,0 +1,11 @@
+package com.prac.local
+
+import com.prac.local.room.entity.RemoteKey
+
+interface RemoteKeyLocalDataSource {
+    suspend fun remoteKey(repoId: Int): RemoteKey?
+
+    suspend fun insertRemoteKeys(remoteKeys: List<RemoteKey>)
+
+    suspend fun clearRemoteKeys()
+}

--- a/local/src/main/java/com/prac/local/RepositoryLocalDataSource.kt
+++ b/local/src/main/java/com/prac/local/RepositoryLocalDataSource.kt
@@ -1,0 +1,21 @@
+package com.prac.local
+
+import androidx.paging.PagingSource
+import com.prac.local.room.entity.Repository
+import kotlinx.coroutines.flow.Flow
+
+interface RepositoryLocalDataSource {
+    fun getRepositories(): PagingSource<Int, Repository>
+
+    fun getRepository(id: Int): Flow<Repository?>
+
+    suspend fun insertRepositories(repos: List<Repository>)
+
+    suspend fun updateStarStateAndStarCount(id: Int, isStarred: Boolean, updatedCount: Int)
+
+    suspend fun updateStarState(id: Int, isStarred: Boolean)
+
+    suspend fun updateStarCount(id: Int, updatedCount: Int)
+
+    suspend fun clearRepositories()
+}

--- a/local/src/main/java/com/prac/local/di/DataSourceModule.kt
+++ b/local/src/main/java/com/prac/local/di/DataSourceModule.kt
@@ -1,11 +1,17 @@
 package com.prac.local.di
 
+import com.prac.local.RemoteKeyLocalDataSource
+import com.prac.local.RepositoryLocalDataSource
 import com.prac.local.TokenLocalDataSource
 import com.prac.local.UserLocalDataSource
 import com.prac.local.datastore.token.TokenDataStoreManager
 import com.prac.local.datastore.user.UserDataStoreManager
+import com.prac.local.impl.RemoteKeyLocalDataSourceImpl
+import com.prac.local.impl.RepositoryLocalDataSourceImpl
 import com.prac.local.impl.TokenLocalDataSourceImpl
 import com.prac.local.impl.UserLocalDataSourceImpl
+import com.prac.local.room.dao.RemoteKeyDao
+import com.prac.local.room.dao.RepositoryDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,4 +31,16 @@ internal class DataSourceModule {
         userDataStoreManager: UserDataStoreManager
     ): UserLocalDataSource =
         UserLocalDataSourceImpl(userDataStoreManager)
+
+    @Provides
+    fun provideRepositoryLocalDataSource(
+        repositoryDao: RepositoryDao
+    ): RepositoryLocalDataSource =
+        RepositoryLocalDataSourceImpl(repositoryDao)
+
+    @Provides
+    fun provideRemoteKeyLocalDataSource(
+        remoteKeyDao: RemoteKeyDao
+    ): RemoteKeyLocalDataSource =
+        RemoteKeyLocalDataSourceImpl(remoteKeyDao)
 }

--- a/local/src/main/java/com/prac/local/di/DatabaseModule.kt
+++ b/local/src/main/java/com/prac/local/di/DatabaseModule.kt
@@ -4,17 +4,21 @@ import android.content.Context
 import androidx.room.Room
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.prac.local.room.dao.RemoteKeyDao
+import com.prac.local.room.dao.RepositoryDao
 import com.prac.local.room.database.RepositoryDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 internal class DatabaseModule {
     @Provides
+    @Singleton
     fun provideRepositoryDatabase(@ApplicationContext context: Context) : RepositoryDatabase {
         return Room.databaseBuilder(
             context,
@@ -23,6 +27,16 @@ internal class DatabaseModule {
         )
             .addMigrations(MIGRATION_1_2)
             .build()
+    }
+
+    @Provides
+    fun provideRepositoryDao(database: RepositoryDatabase) : RepositoryDao {
+        return database.repositoryDao()
+    }
+
+    @Provides
+    fun provideRemoteKeyDao(database: RepositoryDatabase) : RemoteKeyDao {
+        return database.remoteKeyDao()
     }
 
     private val MIGRATION_1_2 = object : Migration(1, 2) {

--- a/local/src/main/java/com/prac/local/impl/RemoteKeyLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/prac/local/impl/RemoteKeyLocalDataSourceImpl.kt
@@ -1,0 +1,20 @@
+package com.prac.local.impl
+
+import com.prac.local.RemoteKeyLocalDataSource
+import com.prac.local.room.dao.RemoteKeyDao
+import com.prac.local.room.entity.RemoteKey
+import javax.inject.Inject
+
+class RemoteKeyLocalDataSourceImpl @Inject constructor(
+    private val remoteKeyDao: RemoteKeyDao
+) : RemoteKeyLocalDataSource {
+    override suspend fun remoteKey(repoId: Int): RemoteKey? =
+        remoteKeyDao.remoteKey(repoId)
+
+    override suspend fun insertRemoteKeys(remoteKeys: List<RemoteKey>) =
+        remoteKeyDao.insertRemoteKeys(remoteKeys)
+
+    override suspend fun clearRemoteKeys() =
+        remoteKeyDao.clearRemoteKeys()
+
+}

--- a/local/src/main/java/com/prac/local/impl/RepositoryLocalDataSourceImpl.kt
+++ b/local/src/main/java/com/prac/local/impl/RepositoryLocalDataSourceImpl.kt
@@ -1,0 +1,34 @@
+package com.prac.local.impl
+
+import androidx.paging.PagingSource
+import com.prac.local.RepositoryLocalDataSource
+import com.prac.local.room.dao.RepositoryDao
+import com.prac.local.room.entity.Repository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class RepositoryLocalDataSourceImpl @Inject constructor(
+    private val repositoryDao: RepositoryDao
+) : RepositoryLocalDataSource {
+    override fun getRepositories(): PagingSource<Int, Repository> =
+        repositoryDao.getRepositories()
+
+    override fun getRepository(id: Int): Flow<Repository?> =
+        repositoryDao.getRepository(id)
+
+    override suspend fun insertRepositories(repos: List<Repository>) =
+        repositoryDao.insertRepositories(repos)
+
+    override suspend fun updateStarStateAndStarCount(id: Int, isStarred: Boolean, updatedCount: Int) =
+        repositoryDao.updateStarStateAndStarCount(id, isStarred, updatedCount)
+
+    override suspend fun updateStarState(id: Int, isStarred: Boolean) =
+        repositoryDao.updateStarState(id, isStarred)
+
+    override suspend fun updateStarCount(id: Int, updatedCount: Int) =
+        repositoryDao.updateStarCount(id, updatedCount)
+
+    override suspend fun clearRepositories() =
+        repositoryDao.clearRepositories()
+
+}

--- a/local/src/test/java/com/prac/local/local/RemoteKeyLocalDataSourceTest.kt
+++ b/local/src/test/java/com/prac/local/local/RemoteKeyLocalDataSourceTest.kt
@@ -1,0 +1,80 @@
+package com.prac.local.local
+
+import com.prac.local.RemoteKeyLocalDataSource
+import com.prac.local.impl.RemoteKeyLocalDataSourceImpl
+import com.prac.local.room.dao.RemoteKeyDao
+import com.prac.local.room.entity.RemoteKey
+import com.prac.shared_test.local.room.FakeRemoteKeyDao
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import kotlin.random.Random
+
+class RemoteKeyLocalDataSourceTest {
+
+    private lateinit var remoteKeyDao: RemoteKeyDao
+    private lateinit var remoteKeyLocalDataSource: RemoteKeyLocalDataSource
+
+    @Before
+    fun setUp() {
+        remoteKeyDao = FakeRemoteKeyDao()
+        remoteKeyLocalDataSource = RemoteKeyLocalDataSourceImpl(remoteKeyDao)
+    }
+
+    @Test
+    fun remoteKey_existingID_remoteKey() = runTest {
+        val remoteKeys = makeRemoteKeys()
+        remoteKeyLocalDataSource.insertRemoteKeys(remoteKeys)
+        val index = 0
+        val remoteKey = remoteKeys[index]
+
+        val result = remoteKeyLocalDataSource.remoteKey(remoteKey.repoId)
+
+        Assert.assertEquals(result, remoteKey)
+    }
+
+    @Test
+    fun remoteKey_notExistingID_null() = runTest {
+        val randomID = Random.nextInt(100)
+
+        val result = remoteKeyLocalDataSource.remoteKey(randomID)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun insertRemoteKeys_insertRemoteKeys_remoteKeys() = runTest {
+        val remoteKeys = makeRemoteKeys()
+        val expectedSize = remoteKeys.size
+
+        remoteKeyLocalDataSource.insertRemoteKeys(remoteKeys)
+
+        repeat(expectedSize) {
+            val result = remoteKeyLocalDataSource.remoteKey(remoteKeys[it].repoId)
+            assertEquals(remoteKeys[it], result)
+        }
+    }
+
+    @Test
+    fun clearRemoteKeys_clearRoom_emptyList() = runTest {
+        val remoteKeys = makeRemoteKeys()
+        remoteKeyLocalDataSource.insertRemoteKeys(remoteKeys)
+        val expectedSize = remoteKeys.size
+
+        remoteKeyLocalDataSource.clearRemoteKeys()
+
+        repeat(expectedSize) {
+            val result = remoteKeyLocalDataSource.remoteKey(remoteKeys[it].repoId)
+            assertNull(result)
+        }
+    }
+
+    private fun makeRemoteKeys() =
+        listOf(
+            RemoteKey(repoId = 0, prevKey = null, nextKey = 2),
+            RemoteKey(repoId = 1, prevKey = null, nextKey = 2),
+        )
+}

--- a/local/src/test/java/com/prac/local/local/RepositoryLocalDataSourceTest.kt
+++ b/local/src/test/java/com/prac/local/local/RepositoryLocalDataSourceTest.kt
@@ -1,0 +1,145 @@
+package com.prac.local.local
+
+import androidx.paging.PagingSource
+import com.prac.local.RepositoryLocalDataSource
+import com.prac.local.impl.RepositoryLocalDataSourceImpl
+import com.prac.local.room.entity.Owner
+import com.prac.local.room.entity.Repository
+import com.prac.shared_test.local.room.FakeRepositoryDao
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class RepositoryLocalDataSourceTest {
+
+    private lateinit var repositoryDao: FakeRepositoryDao
+    private lateinit var repositoryLocalDataSource: RepositoryLocalDataSource
+
+    @Before
+    fun setUp() {
+        repositoryDao = FakeRepositoryDao()
+        repositoryLocalDataSource = RepositoryLocalDataSourceImpl(repositoryDao)
+    }
+
+    @Test
+    fun getRepositories_roomIsEmpty_emptyList() = runTest {
+
+        val result = (repositoryLocalDataSource.getRepositories().load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 10,
+                placeholdersEnabled = false
+            )
+        ) as? PagingSource.LoadResult.Page)?.data
+
+        assertTrue(result?.isEmpty() == true)
+    }
+
+    @Test
+    fun insertRepositories_insertTwoRepositories_twoRepositories() = runTest {
+        val repositories = makeRepositories()
+        val expectedSize = 2
+
+        repositoryLocalDataSource.insertRepositories(repositories)
+
+        val result = (repositoryLocalDataSource.getRepositories().load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 10,
+                placeholdersEnabled = false
+            )
+        ) as? PagingSource.LoadResult.Page)?.data
+        assertEquals(result?.size, expectedSize)
+        assertEquals(result, repositories)
+    }
+
+    @Test
+    fun getRepository_existingID_repository() = runTest {
+        val repositories = makeRepositories()
+        repositoryLocalDataSource.insertRepositories(repositories)
+        val index = 0
+        val id = repositories[index].id
+
+        val result = repositoryLocalDataSource.getRepository(id).first()
+
+        assertEquals(repositories[index], result)
+    }
+
+    @Test
+    fun getRepository_notExistingID_null() = runTest {
+        val repositories = makeRepositories()
+        repositoryLocalDataSource.insertRepositories(repositories)
+        val id = repositories.maxOf { it.id } + 1 // 존재하지 않는 아이디
+
+        val result = repositoryLocalDataSource.getRepository(id).first()
+
+        assertNull(result)
+    }
+
+    @Test
+    fun updateStarStateAndStarCount_existingID_updateStarStateAndStateCountCorrectly() = runTest {
+        val repositories = makeRepositories()
+        repositoryLocalDataSource.insertRepositories(repositories)
+        val index = 0
+        val id = repositories[index].id
+        val isStarred = true
+        val updatedCount = 1
+
+        repositoryLocalDataSource.updateStarStateAndStarCount(id, isStarred, updatedCount)
+
+        val result = repositoryLocalDataSource.getRepository(id).first()
+        assertEquals(result?.isStarred, isStarred)
+        assertEquals(result?.stargazersCount, updatedCount)
+    }
+
+    @Test
+    fun updateStarState_existingID_updateStarStateCorrectly() = runTest {
+        val repositories = makeRepositories()
+        repositoryLocalDataSource.insertRepositories(repositories)
+        val index = 0
+        val id = repositories[index].id
+        val isStarred = true
+
+        repositoryLocalDataSource.updateStarState(id, isStarred)
+
+        val result = repositoryLocalDataSource.getRepository(id).first()
+        assertEquals(result?.isStarred, isStarred)
+    }
+
+    @Test
+    fun updateStarCount_existingID_updateStarCountCorrectly() = runTest {
+        val repositories = makeRepositories()
+        repositoryLocalDataSource.insertRepositories(repositories)
+        val index = 0
+        val id = repositories[index].id
+        val updatedCount = 1
+
+        repositoryLocalDataSource.updateStarCount(id, updatedCount)
+
+        val updatedRepository = repositoryLocalDataSource.getRepository(id).first()
+        assertEquals(updatedRepository?.stargazersCount, updatedCount)
+    }
+
+    @Test
+    fun clearRepositories_clearRoom_emptyList() = runTest {
+        val repositories = makeRepositories()
+        repositoryLocalDataSource.insertRepositories(repositories)
+
+        repositoryLocalDataSource.clearRepositories()
+
+        val result = (repositoryLocalDataSource.getRepositories().load(
+            PagingSource.LoadParams.Refresh(key = null, loadSize = 10, placeholdersEnabled = false)
+        ) as? PagingSource.LoadResult.Page)?.data
+        assertEquals(result?.size, 0)
+    }
+
+    private fun makeRepositories() =
+        listOf(
+            Repository(1, "repo1", Owner("test1", "test1"), 0, "test1", "master", false),
+            Repository(2, "repo2", Owner("test2", "test2"), 0, "test2", "master", false)
+        )
+}

--- a/shared-test/src/main/java/com/prac/shared_test/local/room/FakeRemoteKeyDao.kt
+++ b/shared-test/src/main/java/com/prac/shared_test/local/room/FakeRemoteKeyDao.kt
@@ -1,0 +1,21 @@
+package com.prac.shared_test.local.room
+
+import com.prac.local.room.dao.RemoteKeyDao
+import com.prac.local.room.entity.RemoteKey
+
+class FakeRemoteKeyDao : RemoteKeyDao {
+
+    private val remoteKeys = mutableListOf<RemoteKey>()
+
+    override suspend fun remoteKey(repoId: Int): RemoteKey? {
+        return remoteKeys.find { it.repoId == repoId }
+    }
+
+    override suspend fun insertRemoteKeys(remoteKeys: List<RemoteKey>) {
+        this.remoteKeys.addAll(remoteKeys)
+    }
+
+    override suspend fun clearRemoteKeys() {
+        remoteKeys.clear()
+    }
+}

--- a/shared-test/src/main/java/com/prac/shared_test/local/room/FakeRepositoryDao.kt
+++ b/shared-test/src/main/java/com/prac/shared_test/local/room/FakeRepositoryDao.kt
@@ -1,0 +1,70 @@
+package com.prac.shared_test.local.room
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.prac.local.room.dao.RepositoryDao
+import com.prac.local.room.entity.Repository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeRepositoryDao : RepositoryDao {
+
+    private val repos = mutableListOf<Repository>()
+
+    override fun getRepositories(): PagingSource<Int, Repository> {
+        return object : PagingSource<Int, Repository>() {
+            override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Repository> {
+                val key = params.key ?: 1
+                val pageSize = params.loadSize
+                val startIndex = (key - 1) * pageSize
+                val endIndex = minOf(startIndex + pageSize, repos.size)
+
+                return LoadResult.Page(
+                    data = repos.subList(startIndex, endIndex),
+                    prevKey = if (key == 1) null else key - 1,
+                    nextKey = if (endIndex < repos.size) null else key + 1
+                )
+            }
+
+            override fun getRefreshKey(state: PagingState<Int, Repository>): Int? {
+                return state.anchorPosition?.let { anchorPosition ->
+                    state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                        ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+                }
+            }
+        }
+    }
+
+    override fun getRepository(id: Int): Flow<Repository?> {
+        return flow { emit(repos.find { it.id == id }) }
+    }
+
+    override suspend fun insertRepositories(repos: List<Repository>) {
+        this.repos.addAll(repos)
+    }
+
+    override suspend fun updateStarStateAndStarCount(id: Int, isStarred: Boolean, updatedCount: Int) {
+        val index = repos.indexOfFirst { it.id == id }
+        if (index != -1) {
+            repos[index] = repos[index].copy(isStarred = isStarred, stargazersCount = updatedCount)
+        }
+    }
+
+    override suspend fun updateStarState(id: Int, isStarred: Boolean) {
+        val index = repos.indexOfFirst { it.id == id }
+        if (index != -1) {
+            repos[index] = repos[index].copy(isStarred = isStarred)
+        }
+    }
+
+    override suspend fun updateStarCount(id: Int, updatedCount: Int) {
+        val index = repos.indexOfFirst { it.id == id }
+        if (index != -1) {
+            repos[index] = repos[index].copy(stargazersCount = updatedCount)
+        }
+    }
+
+    override suspend fun clearRepositories() {
+        repos.clear()
+    }
+}

--- a/shared-test/src/main/java/com/prac/shared_test/local/source/FakeRemoteKeyLocalDataSource.kt
+++ b/shared-test/src/main/java/com/prac/shared_test/local/source/FakeRemoteKeyLocalDataSource.kt
@@ -1,0 +1,21 @@
+package com.prac.shared_test.local.source
+
+import com.prac.local.RemoteKeyLocalDataSource
+import com.prac.local.room.entity.RemoteKey
+
+class FakeRemoteKeyLocalDataSource : RemoteKeyLocalDataSource {
+
+    private val remoteKeys = mutableListOf<RemoteKey>()
+
+    override suspend fun remoteKey(repoId: Int): RemoteKey? {
+        return remoteKeys.find { it.repoId == repoId }
+    }
+
+    override suspend fun insertRemoteKeys(remoteKeys: List<RemoteKey>) {
+        this.remoteKeys.addAll(remoteKeys)
+    }
+
+    override suspend fun clearRemoteKeys() {
+        remoteKeys.clear()
+    }
+}

--- a/shared-test/src/main/java/com/prac/shared_test/local/source/FakeRepositoryLocalDataSource.kt
+++ b/shared-test/src/main/java/com/prac/shared_test/local/source/FakeRepositoryLocalDataSource.kt
@@ -1,0 +1,70 @@
+package com.prac.shared_test.local.source
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.prac.local.RepositoryLocalDataSource
+import com.prac.local.room.entity.Repository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class FakeRepositoryLocalDataSource : RepositoryLocalDataSource {
+
+    private val repos = mutableListOf<Repository>()
+
+    override fun getRepositories(): PagingSource<Int, Repository> {
+        return object : PagingSource<Int, Repository>() {
+            override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Repository> {
+                val key = params.key ?: 1
+                val pageSize = params.loadSize
+                val startIndex = (key - 1) * pageSize
+                val endIndex = minOf(startIndex + pageSize, repos.size)
+
+                return LoadResult.Page(
+                    data = repos.subList(startIndex, endIndex),
+                    prevKey = if (key == 1) null else key - 1,
+                    nextKey = if (endIndex < repos.size) null else key + 1
+                )
+            }
+
+            override fun getRefreshKey(state: PagingState<Int, Repository>): Int? {
+                return state.anchorPosition?.let { anchorPosition ->
+                    state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
+                        ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+                }
+            }
+        }
+    }
+
+    override fun getRepository(id: Int): Flow<Repository?> {
+        return flow { emit(repos.find { it.id == id }) }
+    }
+
+    override suspend fun insertRepositories(repos: List<Repository>) {
+        this.repos.addAll(repos)
+    }
+
+    override suspend fun updateStarStateAndStarCount(id: Int, isStarred: Boolean, updatedCount: Int) {
+        val index = repos.indexOfFirst { it.id == id }
+        if (index != -1) {
+            repos[index] = repos[index].copy(isStarred = isStarred, stargazersCount = updatedCount)
+        }
+    }
+
+    override suspend fun updateStarState(id: Int, isStarred: Boolean) {
+        val index = repos.indexOfFirst { it.id == id }
+        if (index != -1) {
+            repos[index] = repos[index].copy(isStarred = isStarred)
+        }
+    }
+
+    override suspend fun updateStarCount(id: Int, updatedCount: Int) {
+        val index = repos.indexOfFirst { it.id == id }
+        if (index != -1) {
+            repos[index] = repos[index].copy(stargazersCount = updatedCount)
+        }
+    }
+
+    override suspend fun clearRepositories() {
+        repos.clear()
+    }
+}


### PR DESCRIPTION
notion - https://www.notion.so/feat-RepoRepository-local-data-source-133a26591b6180e2acd2da5ad1c2d1e0?pvs=4

# AS-IS

- 현재 RepoRepository 에서 database 을 의존성 주입을 받다보니 RepoRepository 를 테스트하는데 unit test 를 하는데 어려움이 있다.

# TO-BE

- RepositoryDao 를 의존성 주입받기 위해 RepositoryLocalDataSource 인터페이스 및 구현체 생성
- RemoteKeyDao 를 의존성 주입받기 위해 RemoteKeyLocalDataSource 인터페이스 및 구현체 생성
- RepoRepository database 의존성 주입 제거 및 RepositoryLocalDataSource, RemoteKeyLocalDataSource 의존성 주입 및 이로 인한 오류 수정