### PR TITLE
refact: ui test 로직 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.ui.test.junit4.android)
+    implementation(libs.androidx.navigation.testing)
     testImplementation(libs.junit)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,11 @@ android {
             )
         }
     }
+    sourceSets {
+        getByName("debug") {
+            java.srcDirs("src/debug/java")
+        }
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8

--- a/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
@@ -4,14 +4,19 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
+import androidx.navigation.NavController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.prac.data.entity.OwnerEntity
@@ -36,6 +41,7 @@ class NavigationTest {
     @get:Rule(order = 1)
     val composeTestRule = createAndroidComposeRule<HiltTestActivity>()
     private val activity get() = composeTestRule.activity
+    private lateinit var navController: TestNavHostController
 
     @Before
     fun init() {
@@ -45,7 +51,9 @@ class NavigationTest {
     @Test
     fun navigationLoginToMainTest() = runTest {
         composeTestRule.setContent {
-            NavGraph(startDestination = Destinations.LOGIN_SCREEN)
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            NavGraph(navController = navController)
         }
 
         val scheme = "test"
@@ -54,9 +62,10 @@ class NavigationTest {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://$host?code=$code"))
         activity.startActivity(intent)
 
-        composeTestRule.awaitIdle()
-
-        composeTestRule.onNodeWithText(activity.getString(R.string.repository)).assertIsDisplayed()
+        composeTestRule.waitUntil {
+            navController.currentBackStackEntry?.destination?.route == Destinations.MAIN_SCREEN
+                    && composeTestRule.onNodeWithText(activity.getString(R.string.repository)).isDisplayed()
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
@@ -139,14 +139,22 @@ class NavigationTest {
     @Test
     fun navigationMainToSettingTest() = runTest {
         composeTestRule.setContent {
-            NavGraph(startDestination = Destinations.MAIN_SCREEN)
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            NavGraph(
+                startDestination = MAIN_SCREEN,
+                navController = navController
+            )
         }
 
         composeTestRule
             .onNode(hasIcon(Icons.Default.AccountCircle))
             .performClick()
 
-        composeTestRule.onNode(hasButton(R.string.logout)).assertIsDisplayed()
+        composeTestRule.waitUntil {
+            navController.currentBackStackEntry?.destination?.route == Destinations.SETTING_SCREEN
+                    && composeTestRule.onNode(hasButton(R.string.logout)).isDisplayed()
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
@@ -5,20 +5,16 @@ import android.net.Uri
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
-import androidx.navigation.NavController
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.espresso.Espresso.pressBack
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.githubrepo.Destinations.DETAIL_SCREEN
@@ -32,9 +28,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
 class NavigationTest {
     @get:Rule(order = 0)

--- a/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
@@ -4,21 +4,14 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onChild
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
-import androidx.compose.ui.test.printToLog
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.prac.data.entity.OwnerEntity
@@ -41,7 +34,7 @@ class NavigationTest {
     var hiltRule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    val composeTestRule = createAndroidComposeRule<HiltTestActivity>()
     private val activity get() = composeTestRule.activity
 
     @Before
@@ -55,8 +48,8 @@ class NavigationTest {
             NavGraph(startDestination = Destinations.LOGIN_SCREEN)
         }
 
-        val scheme = "githubrepo"
-        val host = "localhost:8080"
+        val scheme = "test"
+        val host = "test"
         val code = "success"
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://$host?code=$code"))
         activity.startActivity(intent)

--- a/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
@@ -21,6 +21,7 @@ import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
+import com.prac.githubrepo.Destinations.MAIN_SCREEN
 import com.prac.githubrepo.util.hasButton
 import com.prac.githubrepo.util.hasDrawable
 import com.prac.githubrepo.util.hasIcon
@@ -71,7 +72,12 @@ class NavigationTest {
     @Test
     fun navigationMainToDetailTest() = runTest {
         composeTestRule.setContent {
-            NavGraph(startDestination = Destinations.MAIN_SCREEN)
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            NavGraph(
+                startDestination = MAIN_SCREEN,
+                navController = navController
+            )
         }
 
         val clickPosition = 0
@@ -86,12 +92,14 @@ class NavigationTest {
 
         val expectedRepoDetail = RepoEntity(id = 0, name = "test 0", owner = OwnerEntity("login 0", "avatarUrl 0"), stargazersCount = 5, defaultBranch = "master", updatedAt = "update", isStarred = true)
 
-        composeTestRule.onNodeWithText(expectedRepoDetail.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(expectedRepoDetail.owner.login).assertIsDisplayed()
-        composeTestRule.onNode(hasDrawable(R.drawable.img_glide_profile)).assertIsDisplayed()
-        composeTestRule.onNode(hasDrawable(R.drawable.img_star)).assertIsDisplayed()
-        composeTestRule.onNode(hasDrawable(R.drawable.img_fork)).assertIsDisplayed()
-        composeTestRule.onAllNodesWithText(expectedRepoDetail.stargazersCount.toString()).assertCountEquals(2)
+        composeTestRule.waitUntil {
+            navController.currentBackStackEntry?.destination?.route == Destinations.DETAIL_SCREEN
+                    && composeTestRule.onNodeWithText(expectedRepoDetail.name).isDisplayed()
+                    && composeTestRule.onNodeWithText(expectedRepoDetail.owner.login).isDisplayed()
+                    && composeTestRule.onNode(hasDrawable(R.drawable.img_glide_profile)).isDisplayed()
+                    && composeTestRule.onNode(hasDrawable(R.drawable.img_star)).isDisplayed()
+                    && composeTestRule.onNode(hasDrawable(R.drawable.img_fork)).isDisplayed()
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
@@ -21,6 +21,7 @@ import androidx.test.espresso.Espresso.pressBack
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
+import com.prac.githubrepo.Destinations.DETAIL_SCREEN
 import com.prac.githubrepo.Destinations.MAIN_SCREEN
 import com.prac.githubrepo.util.hasButton
 import com.prac.githubrepo.util.hasDrawable
@@ -105,7 +106,12 @@ class NavigationTest {
     @Test
     fun navigationDetailToMainTest() = runTest {
         composeTestRule.setContent {
-            NavGraph(startDestination = Destinations.MAIN_SCREEN)
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            NavGraph(
+                startDestination = MAIN_SCREEN,
+                navController = navController
+            )
         }
 
         val clickPosition = 0
@@ -118,18 +124,16 @@ class NavigationTest {
             .onNodeWithText("test $clickPosition")
             .performClick()
 
-        val expectedRepoDetail = RepoEntity(id = 0, name = "test 0", owner = OwnerEntity("login 0", "avatarUrl 0"), stargazersCount = 5, defaultBranch = "master", updatedAt = "update", isStarred = true)
-
-        composeTestRule.onNodeWithText(expectedRepoDetail.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(expectedRepoDetail.owner.login).assertIsDisplayed()
-        composeTestRule.onNode(hasDrawable(R.drawable.img_glide_profile)).assertIsDisplayed()
-        composeTestRule.onNode(hasDrawable(R.drawable.img_star)).assertIsDisplayed()
-        composeTestRule.onNode(hasDrawable(R.drawable.img_fork)).assertIsDisplayed()
-        composeTestRule.onAllNodesWithText(expectedRepoDetail.stargazersCount.toString()).assertCountEquals(2)
+        composeTestRule.waitUntil {
+            navController.currentBackStackEntry?.destination?.route == DETAIL_SCREEN
+        }
 
         pressBack()
 
-        composeTestRule.onNodeWithText(activity.getString(R.string.repository)).assertIsDisplayed()
+        composeTestRule.waitUntil {
+            navController.currentBackStackEntry?.destination?.route == MAIN_SCREEN
+                    && composeTestRule.onNodeWithText(activity.getString(R.string.repository)).isDisplayed()
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/NavigationTest.kt
@@ -160,17 +160,27 @@ class NavigationTest {
     @Test
     fun navigationSettingToMainTest() = runTest {
         composeTestRule.setContent {
-            NavGraph(startDestination = Destinations.MAIN_SCREEN)
+            navController = TestNavHostController(LocalContext.current)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            NavGraph(
+                startDestination = MAIN_SCREEN,
+                navController = navController
+            )
         }
 
         composeTestRule
             .onNode(hasIcon(Icons.Default.AccountCircle))
             .performClick()
 
-        composeTestRule.onNode(hasButton(R.string.logout)).assertIsDisplayed()
+        composeTestRule.waitUntil {
+            navController.currentBackStackEntry?.destination?.route == Destinations.SETTING_SCREEN
+        }
 
         pressBack()
 
-        composeTestRule.onNodeWithText(activity.getString(R.string.repository)).assertIsDisplayed()
+        composeTestRule.waitUntil {
+            navController.currentBackStackEntry?.destination?.route == MAIN_SCREEN
+                    && composeTestRule.onNodeWithText(activity.getString(R.string.repository)).isDisplayed()
+        }
     }
 }

--- a/app/src/androidTest/java/com/prac/githubrepo/login/LoginScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/login/LoginScreenTest.kt
@@ -11,7 +11,7 @@ import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
 import com.prac.githubrepo.BuildConfig
-import com.prac.githubrepo.MainActivity
+import com.prac.githubrepo.HiltTestActivity
 import com.prac.githubrepo.R
 import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.LOGIN_FAIL
@@ -31,7 +31,7 @@ class LoginScreenTest {
     var hiltRule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    val composeTestRule = createAndroidComposeRule<HiltTestActivity>()
     private val activity get() = composeTestRule.activity
 
     private var isMainScreen: Boolean = false
@@ -58,8 +58,8 @@ class LoginScreenTest {
 
     @Test
     fun onNewIntent_validIntent_navigateToMainActivity() = runTest {
-        val scheme = "githubrepo"
-        val host = "localhost:8080"
+        val scheme = "test"
+        val host = "test"
         val code = "success"
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://$host?code=$code"))
         activity.startActivity(intent)
@@ -71,8 +71,8 @@ class LoginScreenTest {
 
     @Test
     fun onNewIntent_invalidIntent_showNetworkErrorAlertDialog() = runTest {
-        val scheme = "githubrepo"
-        val host = "localhost:8080"
+        val scheme = "test"
+        val host = "test"
         val code = "ioException"
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://$host?code=$code"))
         activity.startActivity(intent)
@@ -84,8 +84,8 @@ class LoginScreenTest {
 
     @Test
     fun onNewIntent_invalidIntent_showLoginFailureAlertDialog() = runTest {
-        val scheme = "githubrepo"
-        val host = "localhost:8080"
+        val scheme = "test"
+        val host = "test"
         val code = "else"
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://$host?code=$code"))
         activity.startActivity(intent)

--- a/app/src/androidTest/java/com/prac/githubrepo/login/LoginScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/login/LoginScreenTest.kt
@@ -2,7 +2,7 @@ package com.prac.githubrepo.login
 
 import android.content.Intent
 import android.net.Uri
-import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -10,28 +10,20 @@ import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.BuildConfig
 import com.prac.githubrepo.MainActivity
 import com.prac.githubrepo.R
 import com.prac.githubrepo.constants.CONNECTION_FAIL
 import com.prac.githubrepo.constants.LOGIN_FAIL
 import com.prac.githubrepo.util.hasButton
-import com.prac.githubrepo.util.hasDrawable
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.After
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import javax.inject.Inject
 
-@RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
 class LoginScreenTest {
 
@@ -43,9 +35,6 @@ class LoginScreenTest {
     private val activity get() = composeTestRule.activity
 
     private var isMainScreen: Boolean = false
-
-    @Inject
-    lateinit var tokenRepository: TokenRepository
 
     @Before
     fun setUp() {
@@ -60,18 +49,8 @@ class LoginScreenTest {
     }
 
     @Test
-    fun displayLoginScreen_whenUiStateIsIdle() {
-        composeTestRule.onNode(hasDrawable(R.drawable.img_github_icon)).assertIsDisplayed()
-        composeTestRule.onNode(hasButton(R.string.login)).assertIsDisplayed()
-        composeTestRule.onNodeWithText((activity.getString(R.string.login))).assertIsDisplayed()
-        composeTestRule.onNodeWithText(activity.getString(R.string.login_description)).assertIsDisplayed()
-    }
-
-    @Test
     fun loginButtonClick_openBrowser() = runTest {
         composeTestRule.onNode(hasButton(R.string.login)).performClick()
-
-        composeTestRule.awaitIdle()
 
         intended(hasAction(Intent.ACTION_VIEW))
         intended(hasData(Uri.parse(BuildConfig.GITHUB_OAUTH_URI)))
@@ -85,9 +64,9 @@ class LoginScreenTest {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://$host?code=$code"))
         activity.startActivity(intent)
 
-        composeTestRule.awaitIdle()
-
-        assertTrue(isMainScreen)
+        composeTestRule.waitUntil {
+            isMainScreen
+        }
     }
 
     @Test
@@ -98,9 +77,9 @@ class LoginScreenTest {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://$host?code=$code"))
         activity.startActivity(intent)
 
-        composeTestRule.awaitIdle()
-
-        composeTestRule.onNodeWithText(CONNECTION_FAIL).assertExists()
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithText(CONNECTION_FAIL).isDisplayed()
+        }
     }
 
     @Test
@@ -111,15 +90,14 @@ class LoginScreenTest {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://$host?code=$code"))
         activity.startActivity(intent)
 
-        composeTestRule.awaitIdle()
-
-        composeTestRule.onNodeWithText(LOGIN_FAIL).assertExists()
+        composeTestRule.waitUntil {
+            composeTestRule.onNodeWithText(LOGIN_FAIL).isDisplayed()
+        }
     }
 
     private fun setContent() {
         composeTestRule.setContent {
             LoginScreen(
-                viewModel = LoginViewModel(tokenRepository, Dispatchers.IO),
                 onLogin = { isMainScreen = true }
             )
         }

--- a/app/src/androidTest/java/com/prac/githubrepo/main/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/main/MainScreenTest.kt
@@ -12,16 +12,11 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.test.espresso.intent.Intents
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.prac.data.repository.RepoRepository
-import com.prac.data.repository.TokenRepository
-import com.prac.githubrepo.MainActivity
+import com.prac.githubrepo.HiltTestActivity
 import com.prac.githubrepo.R
-import com.prac.githubrepo.util.BackOffWorkManager
 import com.prac.githubrepo.util.hasDrawable
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -29,8 +24,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import javax.inject.Inject
 
 @HiltAndroidTest
 class MainScreenTest {
@@ -39,7 +32,7 @@ class MainScreenTest {
     val hiltRule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    val composeTestRule = createAndroidComposeRule<HiltTestActivity>()
 
     private var isDetailScreen = false
     private var userName = ""

--- a/app/src/androidTest/java/com/prac/githubrepo/main/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/main/MainScreenTest.kt
@@ -32,7 +32,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import javax.inject.Inject
 
-@RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
 class MainScreenTest {
 
@@ -41,12 +40,6 @@ class MainScreenTest {
 
     @get:Rule(order = 1)
     val composeTestRule = createAndroidComposeRule<MainActivity>()
-    private val activity get() = composeTestRule.activity
-
-    @Inject
-    lateinit var tokenRepository: TokenRepository
-    @Inject
-    lateinit var repoRepository: RepoRepository
 
     private var isDetailScreen = false
     private var userName = ""
@@ -62,42 +55,6 @@ class MainScreenTest {
     @After
     fun tearDown() {
         Intents.release()
-    }
-
-    @Test
-    fun displayMainScreen() {
-        // 현재 FakeRepository 10개 씩 리스트를 만들고 있음.
-        // 데이터 형식은 아래과 같음
-        // RepoEntity(id = 0, name = "test 0", owner = OwnerEntity("login 0", "avatarUrl 0"), stargazersCount = 5, defaultBranch = "master", updatedAt = "update", isStarred = true),
-        // RepoEntity(id = 1, name = "test 1", owner = OwnerEntity("login 1", "avatarUrl 1"), stargazersCount = 5, defaultBranch = "master", updatedAt = "update", isStarred = false),
-        // ....
-        val initialItemCount = 10
-
-        composeTestRule
-            .onNodeWithText(activity.getString(R.string.repository))
-            .assertIsDisplayed()
-
-        repeat(initialItemCount) {
-            val expectedImage = if (it % 2 == 0) hasDrawable(R.drawable.img_star) else hasDrawable(R.drawable.img_unstar)
-
-            composeTestRule
-                .onNode(hasTestTag("lazyColumn"))
-                .performScrollToIndex(it)
-                .assertIsDisplayed()
-
-            composeTestRule
-                .onNode(
-            hasDrawable(R.drawable.img_glide_profile)
-                    and hasText("login $it")
-                    and hasText("test $it")
-                    and hasText("master")
-                    and hasText("update")
-                    and hasText("5")
-                )
-                .onChild()
-                .assert(expectedImage)
-                .assertIsDisplayed()
-        }
     }
 
     @Test
@@ -171,7 +128,6 @@ class MainScreenTest {
     private fun setContent() {
         composeTestRule.setContent {
             MainScreen(
-                viewModel = MainViewModel(repoRepository, tokenRepository, FakeBackOffWorkManager(), Dispatchers.IO),
                 onLogout = { },
                 onClickRepository = { userName, repoName ->
                     isDetailScreen = true
@@ -181,12 +137,6 @@ class MainScreenTest {
                 onClickSetting = { }
             )
         }
-    }
-
-    private class FakeBackOffWorkManager: BackOffWorkManager {
-        override fun addWork(uniqueID: String, times: Int, initialDelay: Long, maxDelay: Long, factor: Double, work: suspend () -> Result<*>) { }
-
-        override fun clearWork() { }
     }
 
     private fun SemanticsNodeInteraction.isChangedStarStateAndCount(starMatcher: SemanticsMatcher, expectedStarCount: Int) : Boolean {

--- a/app/src/androidTest/java/com/prac/githubrepo/main/detail/DetailScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/main/detail/DetailScreenTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.intent.Intents
-import com.prac.githubrepo.MainActivity
+import com.prac.githubrepo.HiltTestActivity
 import com.prac.githubrepo.R
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
 import com.prac.githubrepo.util.hasDrawable
@@ -26,7 +26,7 @@ class DetailScreenTest {
     val hiltRule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    val composeTestRule = createAndroidComposeRule<HiltTestActivity>()
     private val activity get() = composeTestRule.activity
 
     private var isMainScreen = false

--- a/app/src/androidTest/java/com/prac/githubrepo/main/detail/DetailScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/main/detail/DetailScreenTest.kt
@@ -1,34 +1,24 @@
 package com.prac.githubrepo.main.detail
 
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.intent.Intents
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.prac.data.repository.RepoRepository
-import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.MainActivity
 import com.prac.githubrepo.R
 import com.prac.githubrepo.constants.INVALID_REPOSITORY
-import com.prac.githubrepo.util.BackOffWorkManager
 import com.prac.githubrepo.util.hasDrawable
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import javax.inject.Inject
 
-@RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
 class DetailScreenTest {
 
@@ -38,11 +28,6 @@ class DetailScreenTest {
     @get:Rule(order = 1)
     val composeTestRule = createAndroidComposeRule<MainActivity>()
     private val activity get() = composeTestRule.activity
-
-    @Inject
-    lateinit var tokenRepository: TokenRepository
-    @Inject
-    lateinit var repoRepository: RepoRepository
 
     private var isMainScreen = false
 
@@ -58,33 +43,6 @@ class DetailScreenTest {
     }
 
     @Test
-    fun displayDetailScreen_uiStateIsContent() {
-        // 데이터 형식은 아래과 같음
-        // RepoEntity(id = 0, name = "test 0", owner = OwnerEntity("login 0", "avatarUrl 0"), stargazersCount = 5, defaultBranch = "master", updatedAt = "update", isStarred = true),
-        // RepoEntity(id = 1, name = "test 1", owner = OwnerEntity("login 1", "avatarUrl 1"), stargazersCount = 5, defaultBranch = "master", updatedAt = "update", isStarred = false),
-        // ....
-        val userName = "test 0"
-        val repoName = "login 0"
-        val starCountAndForkCount = 5
-        composeTestRule.setContent {
-            DetailScreen(
-                viewModel = DetailViewModel(repoRepository, tokenRepository, FakeBackOffWorkManager(), Dispatchers.IO),
-                onLogout = { },
-                onBack = { },
-                userName = userName,
-                repoName = repoName
-            )
-        }
-
-        composeTestRule.onNodeWithText(userName).assertIsDisplayed()
-        composeTestRule.onNodeWithText(repoName).assertIsDisplayed()
-        composeTestRule.onNode(hasDrawable(R.drawable.img_glide_profile)).assertIsDisplayed()
-        composeTestRule.onNode(hasDrawable(R.drawable.img_star)).assertIsDisplayed()
-        composeTestRule.onNode(hasDrawable(R.drawable.img_fork)).assertIsDisplayed()
-        composeTestRule.onAllNodesWithText(starCountAndForkCount.toString()).assertCountEquals(2)
-    }
-
-    @Test
     fun displayDetailScreen_uiStateIsError_showNotFoundRepositoryAlertDialog_and_navigateToMainScreen() = runTest {
         // 데이터 형식은 아래과 같음
         // RepoEntity(id = 0, name = "test 0", owner = OwnerEntity("login 0", "avatarUrl 0"), stargazersCount = 5, defaultBranch = "master", updatedAt = "update", isStarred = true),
@@ -94,7 +52,6 @@ class DetailScreenTest {
         val repoName = "login -1"
         composeTestRule.setContent {
             DetailScreen(
-                viewModel = DetailViewModel(repoRepository, tokenRepository, FakeBackOffWorkManager(), Dispatchers.IO),
                 onLogout = { },
                 onBack = { isMainScreen = true },
                 userName = userName,
@@ -118,7 +75,6 @@ class DetailScreenTest {
         val expectedStarCount = 4
         composeTestRule.setContent {
             DetailScreen(
-                viewModel = DetailViewModel(repoRepository, tokenRepository, FakeBackOffWorkManager(), Dispatchers.IO),
                 onLogout = { },
                 onBack = { },
                 userName = userName,
@@ -143,7 +99,6 @@ class DetailScreenTest {
         val expectedStarCount = 6
         composeTestRule.setContent {
             DetailScreen(
-                viewModel = DetailViewModel(repoRepository, tokenRepository, FakeBackOffWorkManager(), Dispatchers.IO),
                 onLogout = { },
                 onBack = { },
                 userName = userName,
@@ -159,11 +114,5 @@ class DetailScreenTest {
             composeTestRule.onNodeWithText(expectedStarCount.toString()).isDisplayed()
                     && composeTestRule.onNode(hasDrawable(R.drawable.img_star)).isDisplayed()
         }
-    }
-
-    private class FakeBackOffWorkManager: BackOffWorkManager {
-        override fun addWork(uniqueID: String, times: Int, initialDelay: Long, maxDelay: Long, factor: Double, work: suspend () -> Result<*>) { }
-
-        override fun clearWork() { }
     }
 }

--- a/app/src/androidTest/java/com/prac/githubrepo/main/setting/SettingScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/main/setting/SettingScreenTest.kt
@@ -5,24 +5,16 @@ import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.prac.data.repository.RepoRepository
-import com.prac.data.repository.TokenRepository
 import com.prac.githubrepo.MainActivity
 import com.prac.githubrepo.R
-import com.prac.githubrepo.util.BackOffWorkManager
 import com.prac.githubrepo.util.hasButton
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
-import javax.inject.Inject
 
-@RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
 class SettingScreenTest {
 
@@ -35,21 +27,10 @@ class SettingScreenTest {
 
     private var isMainScreen = false
 
-    @Inject
-    lateinit var tokenRepository: TokenRepository
-    @Inject
-    lateinit var repoRepository: RepoRepository
-
     @Before
     fun setup() {
         hiltRule.inject()
         setContent()
-    }
-
-    @Test
-    fun displaySettingScreen_whenUiStateIsIdle() {
-        composeTestRule.onNode(hasButton(R.string.logout)).assertIsDisplayed()
-        composeTestRule.onNodeWithText(activity.getString(R.string.logout)).assertIsDisplayed()
     }
 
     @Test
@@ -88,15 +69,8 @@ class SettingScreenTest {
     private fun setContent() {
         composeTestRule.setContent {
             SettingScreen(
-                viewModel = SettingViewModel(tokenRepository, repoRepository, Dispatchers.IO, FakeBackOffWorkManager()),
                 onLogout = { isMainScreen = true }
             )
         }
-    }
-
-    private class FakeBackOffWorkManager: BackOffWorkManager {
-        override fun addWork(uniqueID: String, times: Int, initialDelay: Long, maxDelay: Long, factor: Double, work: suspend () -> Result<*>) { }
-
-        override fun clearWork() { }
     }
 }

--- a/app/src/androidTest/java/com/prac/githubrepo/main/setting/SettingScreenTest.kt
+++ b/app/src/androidTest/java/com/prac/githubrepo/main/setting/SettingScreenTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.prac.githubrepo.MainActivity
+import com.prac.githubrepo.HiltTestActivity
 import com.prac.githubrepo.R
 import com.prac.githubrepo.util.hasButton
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -22,7 +22,7 @@ class SettingScreenTest {
     var hiltRule = HiltAndroidRule(this)
 
     @get:Rule(order = 1)
-    val composeTestRule = createAndroidComposeRule<MainActivity>()
+    val composeTestRule = createAndroidComposeRule<HiltTestActivity>()
     private val activity get() = composeTestRule.activity
 
     private var isMainScreen = false

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+
+    <application>
+        <activity
+            android:name="com.prac.githubrepo.HiltTestActivity"
+            android:exported="true"
+            android:launchMode="singleTask" >
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="test"
+                    android:host="test" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/debug/java/com/prac/githubrepo/HiltTestActivity.kt
+++ b/app/src/debug/java/com/prac/githubrepo/HiltTestActivity.kt
@@ -4,4 +4,4 @@ import androidx.activity.ComponentActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity()
+class HiltTestActivity : ComponentActivity()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ protobuf-javalite = "3.18.0"
 paging = "3.3.1"
 room = "2.6.1"
 compose-constraintLayout= "1.0.1"
+navigationTesting = "2.8.3"
 
 # plugins
 kapt = "1.5.30"
@@ -74,6 +75,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigationTesting" }
 
 jetbrains-kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 jetbrains-kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }


### PR DESCRIPTION
notion - https://www.notion.so/refact-ui-test-133a26591b6180248ca9ffdb41e0f396?pvs=4

# AS-IS

- 현재 preview 를 통해서 ui 를 확인하고 있지만 test code 에서도 ui test 를 진행하고 있음
- navigation test 에서 navController 에 대한 test code 가 존재하지 않음
- Screen 화면을 만드는데 viewModel 을 직접 생성하고 있음

# TO-BE

- ui 는 preview 를 통해서 확인하고 있기 때문에 test code 에서 제거
- LoginScreen, MainScreen, DetailScreen, SettingScreen viewModel 기본 생성자 사용
- navigation test 에서 navController test code 추가